### PR TITLE
Require pathname

### DIFF
--- a/lib/hako/application.rb
+++ b/lib/hako/application.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'hako/yaml_loader'
+require 'pathname'
 
 module Hako
   class Application

--- a/lib/hako/cli.rb
+++ b/lib/hako/cli.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'hako'
 require 'optparse'
+require 'pathname'
 
 module Hako
   class CLI


### PR DESCRIPTION
In some environment, we have no Pathname.

```sh
$ hako show-yaml foo
/Users/takashi-kokubun/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/hako-0.15.2/lib/hako/cli.rb:179:in `run': uninitialized constant Hako::CLI::ShowYaml::Pathname (NameError)
        from /Users/takashi-kokubun/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/hako-0.15.2/lib/hako/cli.rb:33:in `run'
        from /Users/takashi-kokubun/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/hako-0.15.2/lib/hako/cli.rb:17:in `start'
        from /Users/takashi-kokubun/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/hako-0.15.2/exe/hako:5:in `<top (required)>'
        from /Users/takashi-kokubun/.rbenv/versions/2.3.0/bin/hako:23:in `load'
        from /Users/takashi-kokubun/.rbenv/versions/2.3.0/bin/hako:23:in `<main>'
```