### PR TITLE
hako deploy/oneshot should accept CMD options

### DIFF
--- a/lib/hako/cli.rb
+++ b/lib/hako/cli.rb
@@ -72,7 +72,7 @@ module Hako
         @tag = 'latest'
         @dry_run = false
         @verbose = false
-        parser.parse!(argv)
+        parser.order!(argv)
         @yaml_path = argv.first
 
         if @yaml_path.nil?
@@ -147,7 +147,7 @@ module Hako
         @containers = []
         @env = {}
         @verbose = false
-        parser.parse!(argv)
+        parser.order!(argv)
         @yaml_path = argv.shift
         @argv = argv
 


### PR DESCRIPTION
I want to give command line options to oneshot command like `hako oneshot SOME_APP.yml bundle exec ridgepole --merge --dry-run`, but `--merge` option is wrongly fetched by `hako oneshot` command itself.

Hako should not parse arguments after the definition file.
