### PR TITLE
Support autoscaling group for oneshot tasks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,5 +37,8 @@ Style/TrailingCommaInArguments:
 Style/TrailingCommaInLiteral:
   Enabled: false
 
+Style/PredicateName:
+  Enabled: false
+
 Performance/RedundantBlockCall:
   Enabled: false

--- a/examples/hello-autoscaling-group.yml
+++ b/examples/hello-autoscaling-group.yml
@@ -1,0 +1,14 @@
+scheduler:
+  type: ecs
+  region: ap-northeast-1
+  cluster: eagletmt
+  role: ecsServiceRole
+  autoscaling_group_for_oneshot: hako-batch-cluster
+app:
+  image: ryotarai/hello-sinatra
+  memory: 128
+  cpu: 256
+  env:
+    PORT: 3000
+    MESSAGE: 'hello'
+  command: ['echo', 'heavy offline job']


### PR DESCRIPTION
When `autoscaling_group_for_oneshot` is specified, desired_count of the
autoscaling group is incremented if the cluster doesn't have enough
capacity to run the oneshot task.