### PR TITLE
Support `log_configuration` param

### DIFF
--- a/examples/hello-awslogs-driver.yml
+++ b/examples/hello-awslogs-driver.yml
@@ -1,0 +1,16 @@
+scheduler:
+  type: ecs
+  region: ap-northeast-1
+  cluster: eagletmt
+  desired_count: 1
+app:
+  image: busybox
+  memory: 128
+  cpu: 256
+  command: ['echo', 'hello awslogs']
+  log_configuration:
+    log_driver: awslogs
+    options:
+      awslogs-group: my-logs
+      awslogs-region: ap-northeast-1
+      awslogs-stream-prefix: example

--- a/lib/hako/container.rb
+++ b/lib/hako/container.rb
@@ -27,6 +27,7 @@ module Hako
       port_mappings
       command
       user
+      log_configuration
     ].each do |name|
       define_method(name) do
         @definition[name]
@@ -97,6 +98,7 @@ module Hako
         'mount_points' => [],
         'port_mappings' => [],
         'volumes_from' => [],
+        'log_configuration' => {},
       }
     end
 

--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -438,6 +438,7 @@ module Hako
       # @return [Hash]
       def create_definition(name, container)
         environment = container.env.map { |k, v| { name: k, value: v } }
+        log_configuration = Hash[container.log_configuration.map { |k, v| [k.to_sym, v] }]
         {
           name: name,
           image: container.image_tag,
@@ -453,6 +454,7 @@ module Hako
           command: container.command,
           volumes_from: container.volumes_from,
           user: container.user,
+          log_configuration: log_configuration,
         }
       end
 

--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -440,7 +440,7 @@ module Hako
         environment = container.env.map { |k, v| { name: k, value: v } }
         log_configuration = container.log_configuration
         %w[log_driver options].each do |key|
-          log_configuration[key.to_sym] = log_configuration[key] if log_configuration.has_key?(key)
+          log_configuration[key.to_sym] = log_configuration[key] if log_configuration.key?(key)
         end
         {
           name: name,

--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -438,7 +438,10 @@ module Hako
       # @return [Hash]
       def create_definition(name, container)
         environment = container.env.map { |k, v| { name: k, value: v } }
-        log_configuration = Hash[container.log_configuration.map { |k, v| [k.to_sym, v] }]
+        log_configuration = container.log_configuration
+        %w[log_driver options].each do |key|
+          log_configuration[key.to_sym] = log_configuration[key] if log_configuration.has_key?(key)
+        end
         {
           name: name,
           image: container.image_tag,

--- a/lib/hako/schedulers/ecs_definition_comparator.rb
+++ b/lib/hako/schedulers/ecs_definition_comparator.rb
@@ -7,7 +7,7 @@ module Hako
         @expected_container = expected_container
       end
 
-      CONTAINER_KEYS = %i[image cpu memory memory_reservation links docker_labels user].freeze
+      CONTAINER_KEYS = %i[image cpu memory memory_reservation links docker_labels user log_configuration].freeze
       PORT_MAPPING_KEYS = %i[container_port host_port protocol].freeze
       ENVIRONMENT_KEYS = %i[name value].freeze
       MOUNT_POINT_KEYS = %i[source_volume container_path read_only].freeze


### PR DESCRIPTION
Support `log_configuration` param:

```yml
...
app:
  image: busybox
  memory: 128
  log_configuration:
    log_driver: awslogs
    options:
      awslogs-group: my-logs
      awslogs-region: ap-northeast-1
      awslogs-stream-prefix: example
```