### PR TITLE
Fix EcsDefinitionComparator#different? to avoid redundant TaskDefinition registration

### DIFF
--- a/lib/hako/schedulers/ecs_definition_comparator.rb
+++ b/lib/hako/schedulers/ecs_definition_comparator.rb
@@ -19,6 +19,7 @@ module Hako
         unless actual_container
           return true
         end
+        actual_container = actual_container.to_h
         if different_members?(@expected_container, actual_container, CONTAINER_KEYS)
           return true
         end
@@ -46,7 +47,7 @@ module Hako
       # @return [Boolean]
       def different_members?(expected, actual, keys)
         keys.each do |key|
-          if actual.public_send(key) != expected[key]
+          if actual[key] != expected[key]
             return true
           end
         end
@@ -58,11 +59,11 @@ module Hako
       # @param [Array<String>] keys
       # @return [Boolean]
       def different_array?(expected, actual, key, keys)
-        if expected[key].size != actual.public_send(key).size
+        if expected[key].size != actual[key].size
           return true
         end
         sorted_expected = expected[key].sort_by { |e| keys.map { |k| e[k] }.join('') }
-        sorted_actual = actual.public_send(key).sort_by { |a| keys.map { |k| a.public_send(k) }.join('') }
+        sorted_actual = actual[key].sort_by { |a| keys.map { |k| a[k] }.join('') }
         sorted_expected.zip(sorted_actual) do |e, a|
           if different_members?(e, a, keys)
             return true

--- a/spec/hako/schedulers/ecs_definition_comparator_spec.rb
+++ b/spec/hako/schedulers/ecs_definition_comparator_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hako/schedulers/ecs_definition_comparator'
+
+RSpec.describe Hako::Schedulers::EcsDefinitionComparator do
+  describe '#different?' do
+    let(:ecs_definition_comparator) { described_class.new(expected_container) }
+
+    let(:default_config) do
+      {
+        docker_labels: {},
+        environment: {},
+        links: [],
+        mount_points: [],
+        port_mappings: [],
+        volumes_from: [],
+      }
+    end
+
+    describe 'compares correctly even if the definition includes LogConfiguration' do
+      let(:expected_container) do
+        {
+          name: 'app',
+          log_configuration: {
+            log_driver: 'awslogs',
+            options: {
+              'awslogs-group' => '/loggroup',
+              'awslogs-region' => 'ap-northeast-1',
+              'awslogs-stream-prefix' => 'prefix'
+            }
+          }
+        }.merge(default_config)
+      end
+
+      let(:actual_container) do
+        Aws::ECS::Types::ContainerDefinition.new({
+          name: 'app',
+          log_configuration: Aws::ECS::Types::LogConfiguration.new(
+            log_driver: 'awslogs',
+            options: {
+              'awslogs-group' => '/loggroup',
+              'awslogs-region' => 'ap-northeast-1',
+              'awslogs-stream-prefix' => 'prefix'
+            }
+          )
+        }.merge(default_config))
+      end
+
+      it 'returns valid value' do
+        expect(ecs_definition_comparator.different?(actual_container)).to be_falsy
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi,

When I ran same yml twice: 

### expected:
```
$ hako oneshot --tag=alpine ruby.yml -- ruby -e "p :hoge"
I, [2016-09-25T02:27:23.112698 #27346]  INFO -- : Registered task definition: arn:aws:ecs:ap-northeast-1:1**********7:task-definition/ruby-oneshot:15
....snip....
$ hako oneshot --tag=alpine ruby.yml -- ruby -e "p :hoge"
I, [2016-09-25T02:29:22.069470 #28719]  INFO -- : Task definition isn't changed
....snip....
```

But actually, another TaskDefinition was registered redundantly.

### actual:
```
$ hako oneshot --tag=alpine ruby.yml -- ruby -e "p :hoge"
I, [2016-09-25T02:27:23.112698 #27346]  INFO -- : Registered task definition: arn:aws:ecs:ap-northeast-1:1**********7:task-definition/ruby-oneshot:15
....snip....
$ hako oneshot --tag=alpine ruby.yml -- ruby -e "p :hoge"
I, [2016-09-25T02:27:35.551691 #27518]  INFO -- : Registered task definition: arn:aws:ecs:ap-northeast-1:1**********7:task-definition/ruby-oneshot:16 #<------- registerd twice!!
....snip....
```

### my yml:

```yaml
scheduler:
  cluster: sandbox-hoshino
  desired_count: 1
  region: ap-northeast-1
  type: ecs
app:
  cpu: 0
  image: ruby
  log_configuration:
    log_driver: awslogs
    options:
      awslogs-group: /hoshino-logs
      awslogs-region: ap-northeast-1
      awslogs-stream-prefix: ruby
  memory: 512
  memory_reservation: 128
```

This occurs when .yml has 'log_configuration'.