### PR TITLE
Add privileged to task definition

### DIFF
--- a/examples/hello-privileged-app.yml
+++ b/examples/hello-privileged-app.yml
@@ -1,0 +1,11 @@
+scheduler:
+  type: ecs
+  region: ap-northeast-1
+  cluster: eagletmt
+  desired_count: 1
+app:
+  image: busybox
+  memory: 128
+  cpu: 256
+  command: ['echo', 'hello from --privileged mode']
+  privileged: true

--- a/lib/hako/container.rb
+++ b/lib/hako/container.rb
@@ -110,6 +110,7 @@ module Hako
         'mount_points' => [],
         'port_mappings' => [],
         'volumes_from' => [],
+        'privileged' => false,
       }
     end
 

--- a/lib/hako/container.rb
+++ b/lib/hako/container.rb
@@ -27,6 +27,7 @@ module Hako
       port_mappings
       command
       user
+      privileged
     ].each do |name|
       define_method(name) do
         @definition[name]

--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -456,6 +456,7 @@ module Hako
           docker_labels: container.docker_labels,
           mount_points: container.mount_points,
           command: container.command,
+          privileged: container.privileged,
           volumes_from: container.volumes_from,
           user: container.user,
           log_configuration: container.log_configuration,

--- a/lib/hako/schedulers/ecs_definition_comparator.rb
+++ b/lib/hako/schedulers/ecs_definition_comparator.rb
@@ -32,7 +32,7 @@ module Hako
           struct.member(:command, Schema::Nullable.new(Schema::OrderedArray.new(Schema::String.new)))
           struct.member(:volumes_from, Schema::UnorderedArray.new(volumes_from_schema))
           struct.member(:user, Schema::Nullable.new(Schema::String.new))
-          struct.member(:privileged, Schema::Nullable.new(Schema::Boolean.new))
+          struct.member(:privileged, Schema::Boolean.new)
           struct.member(:log_configuration, Schema::Nullable.new(log_configuration_schema))
         end
       end

--- a/lib/hako/schedulers/ecs_definition_comparator.rb
+++ b/lib/hako/schedulers/ecs_definition_comparator.rb
@@ -32,6 +32,7 @@ module Hako
           struct.member(:command, Schema::Nullable.new(Schema::OrderedArray.new(Schema::String.new)))
           struct.member(:volumes_from, Schema::UnorderedArray.new(volumes_from_schema))
           struct.member(:user, Schema::Nullable.new(Schema::String.new))
+          struct.member(:privileged, Schema::Nullable.new(Schema::Boolean.new))
           struct.member(:log_configuration, Schema::Nullable.new(log_configuration_schema))
         end
       end


### PR DESCRIPTION
I need to pass `--privileged` option which is available in official ECS api from hako definition.

This PR would make it possible to pass privileged option to task definition.