### PR TITLE
Implement --non-graceful option

### DIFF
--- a/lib/hako/cli.rb
+++ b/lib/hako/cli.rb
@@ -65,7 +65,12 @@ module Hako
           Hako.logger.level = Logger::DEBUG
         end
 
-        Commander.new(Application.new(@yaml_path)).deploy(force: @force, tag: @tag, dry_run: @dry_run)
+        Commander.new(Application.new(@yaml_path)).deploy(
+          force: @force,
+          tag: @tag,
+          dry_run: @dry_run,
+          non_graceful: @non_graceful,
+        )
       end
 
       def parse!(argv)
@@ -73,6 +78,7 @@ module Hako
         @tag = 'latest'
         @dry_run = false
         @verbose = false
+        @non_graceful = false
         parser.parse!(argv)
         @yaml_path = argv.first
 
@@ -90,6 +96,7 @@ module Hako
           opts.on('-t', '--tag=TAG', 'Specify tag (default: latest)') { |v| @tag = v }
           opts.on('-n', '--dry-run', 'Enable dry-run mode') { @dry_run = true }
           opts.on('-v', '--verbose', 'Enable verbose logging') { @verbose = true }
+          opts.on('--non-graceful', 'Run deployment after stop target task') { @non_graceful = true }
         end
       end
     end

--- a/lib/hako/commander.rb
+++ b/lib/hako/commander.rb
@@ -17,11 +17,11 @@ module Hako
     # @param [String] tag
     # @param [Boolean] dry_run
     # @return [nil]
-    def deploy(force: false, tag: 'latest', dry_run: false)
+    def deploy(force: false, tag: 'latest', dry_run: false, non_graceful: false)
       containers = load_containers(tag, dry_run: dry_run)
       scripts = @app.yaml.fetch('scripts', []).map { |config| load_script(config, dry_run: dry_run) }
       volumes = @app.yaml.fetch('volumes', [])
-      scheduler = load_scheduler(@app.yaml['scheduler'], scripts, volumes: volumes, force: force, dry_run: dry_run)
+      scheduler = load_scheduler(@app.yaml['scheduler'], scripts, volumes: volumes, force: force, dry_run: dry_run, non_graceful: non_graceful)
 
       scripts.each { |script| script.deploy_starting(containers) }
       scheduler.deploy(containers)
@@ -119,8 +119,8 @@ module Hako
     # @param [Boolean] force
     # @param [Boolean] dry_run
     # @return [Scheduler]
-    def load_scheduler(yaml, scripts, volumes: [], force: false, dry_run:)
-      Loader.new(Hako::Schedulers, 'hako/schedulers').load(yaml.fetch('type')).new(@app.id, yaml, volumes: volumes, scripts: scripts, force: force, dry_run: dry_run)
+    def load_scheduler(yaml, scripts, volumes: [], force: false, dry_run:, non_graceful: false)
+      Loader.new(Hako::Schedulers, 'hako/schedulers').load(yaml.fetch('type')).new(@app.id, yaml, volumes: volumes, scripts: scripts, force: force, dry_run: dry_run, non_graceful: non_graceful)
     end
 
     # @param [Hash] yaml

--- a/lib/hako/scheduler.rb
+++ b/lib/hako/scheduler.rb
@@ -12,12 +12,14 @@ module Hako
     # @param [Array<Script>] scripts
     # @param [Boolean] dry_run
     # @param [Boolean] force
-    def initialize(app_id, options, volumes:, scripts:, dry_run:, force:)
+    # @param [Boolean] non_graceful
+    def initialize(app_id, options, volumes:, scripts:, dry_run:, force:, non_graceful:)
       @app_id = app_id
       @volumes = volumes
       @scripts = scripts
       @dry_run = dry_run
       @force = force
+      @non_graceful = non_graceful
       configure(options)
     end
 

--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -63,6 +63,11 @@ module Hako
             @autoscaling.apply(Aws::ECS::Types::Service.new(cluster_arn: @cluster, service_name: @app_id))
           end
         else
+          if @non_graceful
+            stop
+            wait_for_stop(describe_service)
+          end
+
           task_definition = register_task_definition(definitions)
           if task_definition == :noop
             Hako.logger.info "Task definition isn't changed"
@@ -658,6 +663,26 @@ module Hako
           primary = s.deployments.find { |d| d.status == 'PRIMARY' }
           primary_ready = primary && primary.running_count == primary.desired_count
           if no_active && primary_ready
+            return
+          else
+            sleep 1
+          end
+        end
+      end
+
+      # @param [Aws::ECS::Types::Service] service
+      # @return [nil]
+      def wait_for_stop(service)
+        loop do
+          s = ecs_client.describe_services(cluster: service.cluster_arn, services: [service.service_arn]).services[0]
+
+          if s.nil?
+            Hako.logger.debug "Service #{service.service_arn} could not be described"
+            sleep 1
+            next
+          end
+
+          if s.running_count.zero?
             return
           else
             sleep 1


### PR DESCRIPTION
I implemented new option --non-graceful.
When we run `hako deploy --non-graceful`, the deployment is started after running task is stopped.

# Why --non-graceful is implemented?

Hako deploys an application gracefully in deployment so there are two tasks in a certain moment.
If a task definition is like following,

```yaml
scheduler:
  type: ecs
  region: ap-northeast-1
  desired_count: 1
app:
  image: busybox
  cpu: 128
  memory: 256
  port_mappings:
    - host_port: 30000
      container_port: 80
```

The port 30000 is utilised by an old task so Hako says an error message like following

```
I, [2016-10-07T17:17:39.062109 #52399]  INFO -- : 2016-10-07 17:17:37 +0900: (service app) was unable to place a task because no container instance met all of its requirements. The closest matching (container-instance 5f4f9677-3ca3-4e42-aca5-94e305376673) is already using a port required by your task. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide.
```

If we can allow few downtime, --non-graceful option is useful this situation.