### PR TITLE
Allow enabling cross_zone_load_balancing in elb

### DIFF
--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -617,6 +617,7 @@ module Hako
           deployment_configuration: @deployment_configuration,
         }
         if ecs_elb_client.find_or_create_load_balancer(front_port)
+          ecs_elb_client.modify_attributes
           params[:load_balancers] = [
             @ecs_elb_client.load_balancer_params_for_service.merge(container_name: 'front', container_port: 80),
           ]

--- a/lib/hako/schedulers/ecs_elb.rb
+++ b/lib/hako/schedulers/ecs_elb.rb
@@ -61,6 +61,20 @@ module Hako
         true
       end
 
+      # @return [Types::ModifyLoadBalancerAttributesOutput, nil]
+      def modify_attributes
+        if @elb_config.key?('cross_zone_load_balancing')
+          @elb.modify_load_balancer_attributes(
+            load_balancer_name: name,
+            load_balancer_attributes: {
+              cross_zone_load_balancing: {
+                enabled: @elb_config['cross_zone_load_balancing'],
+              }
+            }
+          )
+        end
+      end
+
       # @return [nil]
       def destroy
         if exist?

--- a/lib/hako/schedulers/ecs_elb_v2.rb
+++ b/lib/hako/schedulers/ecs_elb_v2.rb
@@ -96,6 +96,11 @@ module Hako
       end
 
       # @return [nil]
+      def modify_attributes
+        # Nothing implemented for now
+      end
+
+      # @return [nil]
       def destroy
         unless @elb_v2_config
           return false


### PR DESCRIPTION
I want to enable Cross-Zone Load Balancing in ELB. I added a hook to call modify_load_balancer_attributes for [v1](https://docs.aws.amazon.com/sdkforruby/api/Aws/ElasticLoadBalancing/Client.html#modify_load_balancer_attributes-instance_method) and [v2](https://docs.aws.amazon.com/sdkforruby/api/Aws/ElasticLoadBalancingV2/Client.html#modify_load_balancer_attributes-instance_method). For now, I implemented only what I want.