### PR TITLE
Also rescue Hako::Schedulers::EcsElb

### DIFF
--- a/lib/hako/schedulers/ecs_elb.rb
+++ b/lib/hako/schedulers/ecs_elb.rb
@@ -29,6 +29,8 @@ module Hako
       # @return [Aws::ElasticLoadBalancing::Types::LoadBalancerDescription]
       def describe_load_balancer
         @elb.describe_load_balancers(load_balancer_names: [name]).load_balancer_descriptions[0]
+      rescue Aws::ElasticLoadBalancing::Errors::LoadBalancerNotFound
+        nil
       end
 
       # @param [Fixnum] front_port


### PR DESCRIPTION
Since Hako::Schedulers::EcsElbV2 is rescuing not found error.
Is there any specific reason to not rescue in Hako::Schedulers::EcsElb?