### PR TITLE
Validate variable names when all providers support #ask_keys

### DIFF
--- a/lib/hako/container.rb
+++ b/lib/hako/container.rb
@@ -84,11 +84,13 @@ module Hako
     def expand_env(env)
       env = env.dup
       provider_types = env.delete(PROVIDERS_KEY) || []
+      providers = load_providers(provider_types)
+      expander = EnvExpander.new(providers)
       if @dry_run
+        expander.validate!(env)
         env
       else
-        providers = load_providers(provider_types)
-        EnvExpander.new(providers).expand(env)
+        expander.expand(env)
       end
     end
 

--- a/lib/hako/env_provider.rb
+++ b/lib/hako/env_provider.rb
@@ -14,6 +14,14 @@ module Hako
       raise NotImplementedError
     end
 
+    def can_ask_keys?
+      raise NotImplementedError
+    end
+
+    def ask_keys(_variables)
+      raise NotImplementedError
+    end
+
     private
 
     def validation_error!(message)

--- a/lib/hako/env_providers/file.rb
+++ b/lib/hako/env_providers/file.rb
@@ -25,6 +25,23 @@ module Hako
         env
       end
 
+      # @return [Boolean]
+      def can_ask_keys?
+        true
+      end
+
+      # @param [Array<String>] variables
+      # @return [Array<String>]
+      def ask_keys(variables)
+        keys = []
+        read_from_file do |key, _|
+          if variables.include?(key)
+            keys << key
+          end
+        end
+        keys
+      end
+
       private
 
       # @yieldparam [String] key

--- a/lib/hako/env_providers/yaml.rb
+++ b/lib/hako/env_providers/yaml.rb
@@ -33,6 +33,23 @@ module Hako
         env
       end
 
+      # @return [Boolean]
+      def can_ask_keys?
+        true
+      end
+
+      # @param [Array<String>] variables
+      # @return [Array<String>]
+      def ask_keys(variables)
+        keys = []
+        read_from_yaml do |key, _|
+          if variables.include?(key)
+            keys << key
+          end
+        end
+        keys
+      end
+
       private
 
       # @yieldparam [String] key

--- a/spec/hako/env_providers/file_spec.rb
+++ b/spec/hako/env_providers/file_spec.rb
@@ -15,4 +15,10 @@ RSpec.describe Hako::EnvProviders::File do
       expect(provider.ask(['undefined'])).to eq({})
     end
   end
+
+  describe '#ask_keys' do
+    it 'returns known variables' do
+      expect(provider.ask_keys(%w[username undefined])).to match_array(['username'])
+    end
+  end
 end

--- a/spec/hako/env_providers/yaml_spec.rb
+++ b/spec/hako/env_providers/yaml_spec.rb
@@ -33,4 +33,10 @@ RSpec.describe Hako::EnvProviders::Yaml do
       end
     end
   end
+
+  describe '#ask_keys' do
+    it 'returns known variables' do
+      expect(provider.ask_keys(['username', 'undefined', 'app.db.host'])).to match_array(['username', 'app.db.host'])
+    end
+  end
 end


### PR DESCRIPTION
In `deploy --dry-run`, hako will check if all embedded variables are
resolvable or not without asking actual values. It allows users to check
variable names with less permission for some providers like hako-vault.

----

This is revised version of #26 .
/cc @wata-gh