### PR TITLE
Fix print_definition_in_cli_format glitch related to port_mappings

### DIFF
--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -780,7 +780,7 @@ module Hako
           cmd << '--link' << link
         end
         definition.fetch(:port_mappings).each do |port_mapping|
-          cmd << '--publish' << "#{port_mapping.fetch(:host_port)}:#{port_mapping.fetch(:container_port)}"
+          cmd << '--publish' << "#{port_mapping.fetch('host_port')}:#{port_mapping.fetch('container_port')}"
         end
         definition.fetch(:docker_labels).each do |key, val|
           if key != 'cc.wanko.hako.version'

--- a/lib/hako/scripts/nginx_front.rb
+++ b/lib/hako/scripts/nginx_front.rb
@@ -66,7 +66,7 @@ module Hako
       # @param [Fixnum] front_port
       # @return [Hash]
       def port_mapping(front_port)
-        { container_port: 80, host_port: front_port, protocol: 'tcp' }
+        { 'container_port' => 80, 'host_port' => front_port, 'protocol' => 'tcp' }
       end
 
       # @return [String]

--- a/spec/hako/scripts/nginx_front_spec.rb
+++ b/spec/hako/scripts/nginx_front_spec.rb
@@ -61,9 +61,9 @@ RSpec.describe Hako::Scripts::NginxFront do
 
     it 'configures port mappings' do
       port_mapping = {
-        container_port: 80,
-        host_port: front_port,
-        protocol: 'tcp',
+        'container_port' => 80,
+        'host_port' => front_port,
+        'protocol' => 'tcp',
       }
       expect { script.deploy_started(containers, front_port) }.to change {
         containers['front'].port_mappings


### PR DESCRIPTION
I found a glitch of print_defition_in_cli_format, and this PR fixes it.

The following code will reproduce this bug.

```yaml
scheduler:
  type: ecs
  region: ap-northeast-1
  cluster: test
  desired_count: 1
app:
  image: busybox
  port_mappings:
    - host_port: 0
      container_port: 5000
```

```
[18:35:57]mozamimy@queen:hako-apps (master) (-'x'-).oO(
> hako deploy --dry-run test.yml
/home/mozamimy/var/repo/private/hako/lib/hako/schedulers/ecs.rb:783:in `fetch': key not found: :host_port (KeyError)
        from /home/mozamimy/var/repo/private/hako/lib/hako/schedulers/ecs.rb:783:in `block in print_definition_in_cli_format'
        from /home/mozamimy/var/repo/private/hako/lib/hako/schedulers/ecs.rb:782:in `each'
        from /home/mozamimy/var/repo/private/hako/lib/hako/schedulers/ecs.rb:782:in `print_definition_in_cli_format'
        from /home/mozamimy/var/repo/private/hako/lib/hako/schedulers/ecs.rb:63:in `block in deploy'
        from /home/mozamimy/var/repo/private/hako/lib/hako/schedulers/ecs.rb:62:in `each'
        from /home/mozamimy/var/repo/private/hako/lib/hako/schedulers/ecs.rb:62:in `deploy'
        from /home/mozamimy/var/repo/private/hako/lib/hako/commander.rb:27:in `deploy'
        from /home/mozamimy/var/repo/private/hako/lib/hako/cli.rb:68:in `run'
        from /home/mozamimy/var/repo/private/hako/lib/hako/cli.rb:35:in `run'
        from /home/mozamimy/var/repo/private/hako/lib/hako/cli.rb:19:in `start'
        from /home/mozamimy/var/repo/private/hako/exe/hako:5:in `<top (required)>'
        from /home/mozamimy/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/bin/hako:22:in `load'
        from /home/mozamimy/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/bin/hako:22:in `<main>'
```