### PR TITLE
W/o app's elb, `exist?` should return falsy value

### DIFF
--- a/lib/hako/schedulers/ecs_elb.rb
+++ b/lib/hako/schedulers/ecs_elb.rb
@@ -94,9 +94,6 @@ module Hako
       # @return [Boolean]
       def exist?
         describe_load_balancer
-        true
-      rescue Aws::ElasticLoadBalancing::Errors::LoadBalancerNotFound
-        false
       end
 
       # @return [String]

--- a/lib/hako/schedulers/ecs_elb.rb
+++ b/lib/hako/schedulers/ecs_elb.rb
@@ -93,7 +93,7 @@ module Hako
 
       # @return [Boolean]
       def exist?
-        describe_load_balancer
+        describe_load_balancer != nil
       end
 
       # @return [String]


### PR DESCRIPTION
`exist?` always returns true because `describe_load_balancer` rescues
LoadBalancerNotFound error (since #27).
As a result, we can't create any elb.
`exist?` should return falsy value when there's no elb.