### PR TITLE
Raise error when env value is not String

### DIFF
--- a/lib/hako/env_expander.rb
+++ b/lib/hako/env_expander.rb
@@ -90,7 +90,10 @@ module Hako
     def parse_env(env)
       parsed_env = {}
       env.each do |key, val|
-        parsed_env[key] = parse(val.to_s)
+        unless val.is_a?(String)
+          raise ExpansionError.new("#{key} must be a String but got #{val.class}: #{val.inspect}")
+        end
+        parsed_env[key] = parse(val)
       end
       parsed_env
     end


### PR DESCRIPTION
I'd like to prevent these common mistakes.

- `FOO: #{foo}`
  - `#{foo}` must be quoted because `#` is parsed as comment
- `FOO_RATIO: 0.5`
  - Since all values were converted with `to_s`, it could contain errors
- `FOO: on`
  - Since `on` is a boolean keyword in YAML, `FOO` is set to `"true"`.

----

This is relatively a big change, so I'm going to release v1.0.0 including this change.