### PR TITLE
Merge instead of overwriting

### DIFF
--- a/lib/hako/yaml_loader.rb
+++ b/lib/hako/yaml_loader.rb
@@ -36,12 +36,12 @@ module Hako
       def revive_hash(hash, o)
         super(hash, o).tap do |r|
           if r[SHOVEL].is_a?(Hash)
-            h2 = {}
+            h2 = Hash.new {|h, k| h[k] = Hash.new }
             r.each do |k, v|
               if k == SHOVEL
                 h2.merge!(v)
               else
-                h2[k] = v
+                h2[k].merge!(v)
               end
             end
             r.replace(h2)


### PR DESCRIPTION
If it gets merged instead of overwriting it will be more convenient.

## sample

```
# sample.yml
・・・
  front:
    <<: !include common.yml
    env:
      CLIENT_MAX_BODY_SIZE: 12M
・・・

# common.yml 
・・・
env:
  LISTEN_UNIX: /tmp/unicorn/unicorn.sock
・・・

```

## before
```
   "env"=>{"CLIENT_MAX_BODY_SIZE"=>"12M"}},
```

## after
```
   "env"=>{"LISTEN_UNIX"=>"/tmp/unicorn/unicorn.sock", "CLIENT_MAX_BODY_SIZE"=>"12M"}},
```
