### PR TITLE
FIX exception when container instance empty 

### DIFF
--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -841,7 +841,8 @@ module Hako
             raise Error.new("AutoScaling Group '#{@autoscaling_group_for_oneshot}' does not exist")
           end
 
-          container_instances = ecs_client.list_container_instances(cluster: @cluster).flat_map { |c| ecs_client.describe_container_instances(cluster: @cluster, container_instances: c.container_instance_arns).container_instances }
+          arns = ecs_client.list_container_instances(cluster: @cluster).container_instance_arns
+          container_instances = arns.empty? ? [] : ecs_client.describe_container_instances(cluster: @cluster, container_instances: arns).container_instances
           if has_capacity?(task_definition, container_instances)
             Hako.logger.info("There's remaining capacity. Start retrying...")
             return true


### PR DESCRIPTION
Hello.
I using `hako oneshot`.
Hako support scale out when resources not enough.

In my case, the number of container instances is zero, when before `hako oneshot` run.
I expect scale out when `hako oneshot` run.

But Exception raised, message is `Container instance cannot be empty.
 (Aws::ECS::Errors::InvalidParameterException)`.
Because `container_instances` of `describe_container_instances` is required.

reference is [here](http://docs.aws.amazon.com/sdkforruby/api/Aws/ECS/Client.html#describe_container_instances-instance_method)

## Validation

```yaml
scheduler:
  type: ecs
  region: ap-northeast-1
  cluster: cluster_hoge
  autoscaling_group_for_oneshot: test-asg
app:
  image: busybox
  memory: 1000
```

```sh
$ bundle exec hako oneshot hoge.yml -- echo "Hello"
```