### PR TITLE
Add rcredstash env_provider

### DIFF
--- a/hako.gemspec
+++ b/hako.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '>= 0.36.0'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'yard'
-  spec.add_development_dependency 'rcredstash'
+  spec.add_development_dependency 'rcredstash', '>= 0.11.0'
 end

--- a/hako.gemspec
+++ b/hako.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '>= 0.36.0'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'yard'
+  spec.add_development_dependency 'rcredstash'
 end

--- a/lib/hako/env_providers/rcredstash.rb
+++ b/lib/hako/env_providers/rcredstash.rb
@@ -44,8 +44,6 @@ module Hako
 
       private
 
-      # @yieldparam [String] key
-      # @yieldparam [String] val
       # @return [Hash<String, Integer>]
       def read_keys_from_credstash()
         @client.list

--- a/lib/hako/env_providers/rcredstash.rb
+++ b/lib/hako/env_providers/rcredstash.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'hako/env_provider'
+require 'rcredstash'
+
+module Hako
+  module EnvProviders
+    class Rcredstash < EnvProvider
+      # @param [Pathname] root_path
+      # @param [Hash<String, Object>] options
+      def initialize(root_path, options)
+        @client = options['client'] || CredStash
+      end
+
+      # @param [Array<String>] variables
+      # @return [Hash<String, String>]
+      def ask(variables)
+        env = {}
+        variables.each do |key|
+          val = get_value_from_credstash(key)
+          if val
+            env[key] = val
+          end
+        end
+        env
+      end
+
+      # @return [Boolean]
+      def can_ask_keys?
+        true
+      end
+
+      # @param [Array<String>] variables
+      # @return [Array<String>]
+      def ask_keys(variables)
+        keys = []
+        read_keys_from_credstash.each do |key, _|
+          if variables.include?(key)
+            keys << key
+          end
+        end
+        keys
+      end
+
+      private
+
+      # @yieldparam [String] key
+      # @yieldparam [String] val
+      # @return [Hash<String, Integer>]
+      def read_keys_from_credstash()
+        @client.list
+      end
+
+      # @param [String] key
+      # @return [String]
+      def get_value_from_credstash(key)
+        @client.get(key)
+      end
+    end
+  end
+end

--- a/spec/hako/env_providers/rcredstash_spec.rb
+++ b/spec/hako/env_providers/rcredstash_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'hako/env_providers/rcredstash'
+
+RSpec.describe Hako::EnvProviders::Rcredstash do
+  let(:options) {}
+
+  describe '#ask' do
+    let(:stub_client) do
+      allow(CredStash).to receive(:get).and_return('veryverysecret')
+    end
+    it 'returns known variables' do
+      expect(described_class.new(fixture_root, {:client => stub_client}).ask(['password'])).to eq('password' => 'veryverysecret')
+    end
+  end
+
+
+  describe '#ask_empty' do
+    let(:stub_client) do
+      allow(CredStash).to receive(:get)
+    end
+    it 'returns empty to unknown variables' do
+      expect(described_class.new(fixture_root, {:client => stub_client}).ask(['undefined'])).to eq({})
+    end
+  end
+
+  describe '#ask_keys' do
+    let(:stub_client) do
+      allow(CredStash).to receive(:list).and_return(['password'])
+    end
+    it 'returns known variables' do
+      expect(described_class.new(fixture_root, {:client => stub_client}).ask_keys(%w[password undefined])).to match_array(['password'])
+    end
+  end
+end


### PR DESCRIPTION
I opened this pull request to add a new env_provider using `rcredstash` ( <https://github.com/adorechic/rcredstash> ). This reason is that I want to encrypt the value set for the environment variable in my situation.
Please look at it.

```
$ rcredstash put encrypted.some_password 
secret value> veryverysecret
$ rcredstash get encrypted.some_password 
veryverysecret
```

```
  env:
    $providers:
      - type: rcredstash
    SOME_PASSWORD: ‘#{encrypted.some_password}'
```

```
Environment Variables
Key	Value
SOME_PASSWORD	veryverysecret
```