### PR TITLE
Support LinuxParameters option with ECS

### DIFF
--- a/examples/hello-cap-add-app.yml
+++ b/examples/hello-cap-add-app.yml
@@ -1,0 +1,13 @@
+scheduler:
+  type: ecs
+  region: ap-northeast-1
+  cluster: eagletmt
+  desired_count: 1
+app:
+  image: busybox
+  memory: 128
+  cpu: 256
+  command: ['echo', 'hello with SYS_RAWIO']
+  linux_parameters:
+    capabilities:
+      add: ['SYS_RAWIO']

--- a/hako.gemspec
+++ b/hako.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'aws-sdk-cloudwatch'
   spec.add_dependency 'aws-sdk-cloudwatchlogs'
   spec.add_dependency 'aws-sdk-ec2'
-  spec.add_dependency 'aws-sdk-ecs'
+  spec.add_dependency 'aws-sdk-ecs', '>= 1.2.0'
   spec.add_dependency 'aws-sdk-elasticloadbalancing'
   spec.add_dependency 'aws-sdk-elasticloadbalancingv2'
   spec.add_dependency 'aws-sdk-s3'

--- a/lib/hako/container.rb
+++ b/lib/hako/container.rb
@@ -29,7 +29,6 @@ module Hako
       command
       user
       privileged
-      linux_parameters
     ].each do |name|
       define_method(name) do
         @definition[name]
@@ -108,6 +107,22 @@ module Hako
           {
             hostname: extra_host.fetch('hostname'),
             ip_address: extra_host.fetch('ip_address'),
+          }
+        end
+      end
+    end
+
+    # @return [Hash, nil]
+    def linux_parameters
+      if @definition.key?('linux_parameters')
+        conf = @definition['linux_parameters']
+        if conf.key?('capabilities')
+          cap = conf['capabilities']
+          {
+            capabilities: {
+              add: cap.fetch('add', []),
+              drop: cap.fetch('drop', [])
+            }
           }
         end
       end

--- a/lib/hako/container.rb
+++ b/lib/hako/container.rb
@@ -29,6 +29,7 @@ module Hako
       command
       user
       privileged
+      linux_parameters
     ].each do |name|
       define_method(name) do
         @definition[name]

--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -1001,7 +1001,7 @@ module Hako
         if definition[:linux_parameters]
           if definition[:linux_parameters]['capabilities']
             cp = definition[:linux_parameters]['capabilities']
-            %w(add drop).each do |a_or_d|
+            %w[add drop].each do |a_or_d|
               cp[a_or_d]&.each do |c|
                 cmd << "--cap-#{a_or_d}=#{c}"
               end

--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -513,6 +513,7 @@ module Hako
           mount_points: container.mount_points,
           command: container.command,
           privileged: container.privileged,
+          linux_parameters: container.linux_parameters,
           volumes_from: container.volumes_from,
           user: container.user,
           log_configuration: container.log_configuration,
@@ -996,6 +997,16 @@ module Hako
         end
         if definition[:privileged]
           cmd << '--privileged'
+        end
+        if definition[:linux_parameters]
+          if definition[:linux_parameters]['capabilities']
+            cp = definition[:linux_parameters]['capabilities']
+            %w(add drop).each do |a_or_d|
+              cp[a_or_d]&.each do |c|
+                cmd << "--cap-#{a_or_d}=#{c}"
+              end
+            end
+          end
         end
         definition.fetch(:volumes_from).each do |volumes_from|
           p volumes_from

--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -999,9 +999,9 @@ module Hako
           cmd << '--privileged'
         end
         if definition[:linux_parameters]
-          if definition[:linux_parameters]['capabilities']
-            cp = definition[:linux_parameters]['capabilities']
-            %w[add drop].each do |a_or_d|
+          if definition[:linux_parameters][:capabilities]
+            cp = definition[:linux_parameters][:capabilities]
+            %i[add drop].each do |a_or_d|
               cp[a_or_d]&.each do |c|
                 cmd << "--cap-#{a_or_d}=#{c}"
               end

--- a/lib/hako/schedulers/ecs_definition_comparator.rb
+++ b/lib/hako/schedulers/ecs_definition_comparator.rb
@@ -37,6 +37,7 @@ module Hako
           struct.member(:log_configuration, Schema::Nullable.new(log_configuration_schema))
           struct.member(:ulimits, Schema::Nullable.new(ulimits_schema))
           struct.member(:extra_hosts, Schema::Nullable.new(extra_hosts_schema))
+          struct.member(:linux_parameters, Schema::Nullable.new(linux_parameters_schema))
         end
       end
 
@@ -86,6 +87,19 @@ module Hako
           struct.member(:name, Schema::String.new)
           struct.member(:hard_limit, Schema::Integer.new)
           struct.member(:soft_limit, Schema::Integer.new)
+        end
+      end
+
+      def linux_parameters_schema
+        Schema::Structure.new.tap do |struct|
+          struct.member(:capabilities, capabilities_schema)
+        end
+      end
+
+      def capabilities_schema
+        Schema::Structure.new.tap do |struct|
+          struct.member(:add, Schema::UnorderedArray.new(Schema::String.new))
+          struct.member(:drop, Schema::UnorderedArray.new(Schema::String.new))
         end
       end
 

--- a/spec/hako/schedulers/ecs_definition_comparator_spec.rb
+++ b/spec/hako/schedulers/ecs_definition_comparator_spec.rb
@@ -19,6 +19,36 @@ RSpec.describe Hako::Schedulers::EcsDefinitionComparator do
       }
     end
 
+    describe 'compares correctly even if the definition includes LinuxParameters' do
+      let(:expected_container) do
+        {
+          name: 'app',
+          linux_parameters: {
+            capabilities: {
+              add: ['ALL'],
+              drop: ['NET_ADMIN']
+            }
+          }
+        }.merge(default_config)
+      end
+
+      let(:actual_container) do
+        Aws::ECS::Types::ContainerDefinition.new({
+          name: 'app',
+          linux_parameters: Aws::ECS::Types::LinuxParameters.new(
+            capabilities: {
+              add: ['ALL'],
+              drop: ['NET_ADMIN']
+            }
+          )
+        }.merge(default_config))
+      end
+
+      it 'returns valid value' do
+        expect(ecs_definition_comparator).to_not be_different(actual_container)
+      end
+    end
+
     describe 'compares correctly even if the definition includes LogConfiguration' do
       let(:expected_container) do
         {

--- a/spec/hako/schedulers/ecs_spec.rb
+++ b/spec/hako/schedulers/ecs_spec.rb
@@ -70,6 +70,7 @@ RSpec.describe Hako::Schedulers::Ecs do
         mount_points: [],
         command: nil,
         privileged: false,
+        linux_parameters: nil,
         volumes_from: [],
         user: nil,
         log_configuration: nil,


### PR DESCRIPTION
ECS now supports new LinuxParameters option where we can pass `--cap-add` and `--cap-drop` option to `docker run` .

@eagletmt please review 🙏 