### PR TITLE
Use the region in a definition when instanciating AWS Client objects

### DIFF
--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -652,7 +652,7 @@ module Hako
       # The JSON is supposed to be stored from Amazon ECS Event Stream.
       # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/cloudwatch_event_stream.html
       def poll_task_status_from_s3(task)
-        s3 = Aws::S3::Client.new
+        s3 = Aws::S3::Client.new(region: @region)
         task_arn = task.task_arn
         uri = URI.parse(@oneshot_notification_prefix)
         prefix = uri.path.sub(%r{\A/}, '')
@@ -886,7 +886,7 @@ module Hako
           hako_task_id: @hako_task_id,
         )
         Hako.logger.info("Unable to start tasks. Publish message to #{@autoscaling_topic_for_oneshot}: #{message}")
-        sns_client = Aws::SNS::Client.new
+        sns_client = Aws::SNS::Client.new(region: @region)
         resp = sns_client.publish(topic_arn: @autoscaling_topic_for_oneshot, message: message)
         Hako.logger.info("Sent message_id=#{resp.message_id}")
         sleep(RUN_TASK_INTERVAL)
@@ -896,7 +896,7 @@ module Hako
       MIN_ASG_INTERVAL = 1
       MAX_ASG_INTERVAL = 120
       def try_scale_out_with_as(task_definition)
-        autoscaling = Aws::AutoScaling::Client.new
+        autoscaling = Aws::AutoScaling::Client.new(region: @region)
         interval = MIN_ASG_INTERVAL
         Hako.logger.info("Unable to start tasks. Start trying scaling out '#{@autoscaling_group_for_oneshot}'")
         loop do


### PR DESCRIPTION
# Summary
Hako oneshot fails if autoscaling is required when hako is executed in EC2 instance with an instance role.

Such instances don't require credential information to execute hako, so there is no `~/.aws/config` file and the default region is not defined.

Thus, the AWS client API library cannot retrieve default region information from the file and fail to instantiate AWS Client object without passing region as an argument.

Hako users already defined the specific region in hako task definitions file. So, I think we should use the value instead of default region in `~/.aws/config` in the same way as ec2 client (https://github.com/0gajun/hako/blob/f80514da201da180dfb611c37da0f0068540f622/lib/hako/schedulers/ecs.rb#L291).

I change code to pass the region as an argument.

# Misc
My encountered problem is only in hako's autoscaling feature.
However, some other lines have potential bugs like my problem.
So, I additionally fixed the instanciation of `Aws::S3::Client` and `Aws::SNS::Client`.

# Encountered Error Detail

I encountered a following error when I used hako in an ec2 instance with an instance role.

```
ubuntu@ip-172-31-29-186:~/hako$ bundle exec hako oneshot test.yml echo 'hoge'
I, [2017-11-21T06:28:29.665001 #22419]  INFO -- : Task definition isn't changed: arn:aws:ecs:ap-northeast-1:xxxxxxxx:task-definition/test-oneshot:2
bundler: failed to load command: hako (/home/ubuntu/hako/vendor/bundle/ruby/2.4.0/bin/hako)
Aws::Errors::MissingRegionError: missing region; use :region option or export region name to ENV['AWS_REGION']
  /home/ubuntu/hako/vendor/bundle/ruby/2.4.0/gems/aws-sdk-core-3.9.0/lib/aws-sdk-core/plugins/signature_v4.rb:88:in `build_signer'
  /home/ubuntu/hako/vendor/bundle/ruby/2.4.0/gems/aws-sdk-core-3.9.0/lib/aws-sdk-core/plugins/signature_v4.rb:9:in `block in <class:SignatureV4>'
  /home/ubuntu/hako/vendor/bundle/ruby/2.4.0/gems/aws-sdk-core-3.9.0/lib/seahorse/client/configuration.rb:70:in `call'
  /home/ubuntu/hako/vendor/bundle/ruby/2.4.0/gems/aws-sdk-core-3.9.0/lib/seahorse/client/configuration.rb:205:in `block in resolve_defaults'
  /home/ubuntu/hako/vendor/bundle/ruby/2.4.0/gems/aws-sdk-core-3.9.0/lib/seahorse/client/configuration.rb:57:in `each'
  /home/ubuntu/hako/vendor/bundle/ruby/2.4.0/gems/aws-sdk-core-3.9.0/lib/seahorse/client/configuration.rb:57:in `each'
  /home/ubuntu/hako/vendor/bundle/ruby/2.4.0/gems/aws-sdk-core-3.9.0/lib/seahorse/client/configuration.rb:204:in `resolve_defaults'
  /home/ubuntu/hako/vendor/bundle/ruby/2.4.0/gems/aws-sdk-core-3.9.0/lib/seahorse/client/configuration.rb:200:in `value_at'
  /home/ubuntu/hako/vendor/bundle/ruby/2.4.0/gems/aws-sdk-core-3.9.0/lib/seahorse/client/configuration.rb:189:in `block in resolve'
  /home/ubuntu/.rbenv/versions/2.4.2/lib/ruby/2.4.0/set.rb:324:in `each_key'
  /home/ubuntu/.rbenv/versions/2.4.2/lib/ruby/2.4.0/set.rb:324:in `each'
  /home/ubuntu/hako/vendor/bundle/ruby/2.4.0/gems/aws-sdk-core-3.9.0/lib/seahorse/client/configuration.rb:189:in `resolve'
  /home/ubuntu/hako/vendor/bundle/ruby/2.4.0/gems/aws-sdk-core-3.9.0/lib/seahorse/client/configuration.rb:177:in `apply_defaults'
  /home/ubuntu/hako/vendor/bundle/ruby/2.4.0/gems/aws-sdk-core-3.9.0/lib/seahorse/client/configuration.rb:150:in `build!'
  /home/ubuntu/hako/vendor/bundle/ruby/2.4.0/gems/aws-sdk-core-3.9.0/lib/seahorse/client/base.rb:62:in `build_config'
  /home/ubuntu/hako/vendor/bundle/ruby/2.4.0/gems/aws-sdk-core-3.9.0/lib/seahorse/client/base.rb:19:in `initialize'
  /home/ubuntu/hako/vendor/bundle/ruby/2.4.0/gems/aws-sdk-autoscaling-1.3.0/lib/aws-sdk-autoscaling/client.rb:143:in `initialize'
  /home/ubuntu/hako/vendor/bundle/ruby/2.4.0/gems/aws-sdk-core-3.9.0/lib/seahorse/client/base.rb:99:in `new'
  /home/ubuntu/hako/lib/hako/schedulers/ecs.rb:899:in `try_scale_out_with_as'
  /home/ubuntu/hako/lib/hako/schedulers/ecs.rb:873:in `on_no_tasks_started'
  /home/ubuntu/hako/lib/hako/schedulers/ecs.rb:555:in `rescue in run_task'
  /home/ubuntu/hako/lib/hako/schedulers/ecs.rb:530:in `run_task'
  /home/ubuntu/hako/lib/hako/schedulers/ecs.rb:168:in `oneshot'
  /home/ubuntu/hako/lib/hako/commander.rb:58:in `block in oneshot'
  /home/ubuntu/hako/lib/hako/commander.rb:97:in `with_oneshot_signal_handlers'
  /home/ubuntu/hako/lib/hako/commander.rb:57:in `oneshot'
  /home/ubuntu/hako/lib/hako/cli.rb:147:in `run'
  /home/ubuntu/hako/lib/hako/cli.rb:36:in `run'
  /home/ubuntu/hako/lib/hako/cli.rb:20:in `start'
  /home/ubuntu/hako/exe/hako:6:in `<top (required)>'
  /home/ubuntu/hako/vendor/bundle/ruby/2.4.0/bin/hako:23:in `load'
  /home/ubuntu/hako/vendor/bundle/ruby/2.4.0/bin/hako:23:in `<top (required)>'
```