### PR TITLE
Pass AWS region of scheduler to AWS clients

### DIFF
--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -44,7 +44,7 @@ module Hako
         end
         @dynamic_port_mapping = options.fetch('dynamic_port_mapping', @ecs_elb_options.nil?)
         if options.key?('autoscaling')
-          @autoscaling = EcsAutoscaling.new(options.fetch('autoscaling'), dry_run: @dry_run)
+          @autoscaling = EcsAutoscaling.new(options.fetch('autoscaling'), @region, dry_run: @dry_run)
         end
         @autoscaling_group_for_oneshot = options.fetch('autoscaling_group_for_oneshot', nil)
         @autoscaling_topic_for_oneshot = options.fetch('autoscaling_topic_for_oneshot', nil)

--- a/lib/hako/schedulers/ecs_autoscaling.rb
+++ b/lib/hako/schedulers/ecs_autoscaling.rb
@@ -8,7 +8,8 @@ require 'hako/error'
 module Hako
   module Schedulers
     class EcsAutoscaling
-      def initialize(options, dry_run:)
+      def initialize(options, region, dry_run:)
+        @region = region
         @dry_run = dry_run
         @role_arn = required_option(options, 'role_arn')
         @min_capacity = required_option(options, 'min_capacity')
@@ -124,12 +125,12 @@ module Hako
 
       # @return [Aws::ApplicationAutoScaling]
       def autoscaling_client
-        @autoscaling_client ||= Aws::ApplicationAutoScaling::Client.new
+        @autoscaling_client ||= Aws::ApplicationAutoScaling::Client.new(region: @region)
       end
 
       # @return [Aws::CloudWatch::Client]
       def cw_client
-        @cw_client ||= Aws::CloudWatch::Client.new
+        @cw_client ||= Aws::CloudWatch::Client.new(region: @region)
       end
 
       # @param [Aws::ECS::Types::Service] service


### PR DESCRIPTION
~~This change could break existing deployments where the region you specify in the scheduler settings is different from the default one that aws-sdk-ruby uses.~~

`Aws::ApplicationAutoScaling::Client#register_scalable_target` should fail in that case, I guess.