### PR TITLE
Eliminate memory parameter from dry-run output if it's not given

### DIFF
--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -1038,7 +1038,7 @@ module Hako
         cmd << '--name' << definition.fetch(:name)
         cmd << '--cpu-shares' << definition.fetch(:cpu)
         if definition[:memory]
-          cmd << '--memory' << definition[:memory]
+          cmd << '--memory' << "#{definition[:memory]}M"
         end
         definition.fetch(:links).each do |link|
           cmd << '--link' << link

--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -1037,7 +1037,9 @@ module Hako
         cmd = %w[docker run]
         cmd << '--name' << definition.fetch(:name)
         cmd << '--cpu-shares' << definition.fetch(:cpu)
-        cmd << '--memory' << definition.fetch(:memory)
+        if definition[:memory]
+          cmd << '--memory' << definition[:memory]
+        end
         definition.fetch(:links).each do |link|
           cmd << '--link' << link
         end

--- a/lib/hako/schedulers/ecs_definition_comparator.rb
+++ b/lib/hako/schedulers/ecs_definition_comparator.rb
@@ -23,7 +23,7 @@ module Hako
         Schema::Structure.new.tap do |struct|
           struct.member(:image, Schema::String.new)
           struct.member(:cpu, Schema::Integer.new)
-          struct.member(:memory, Schema::Integer.new)
+          struct.member(:memory, Schema::Nullable.new(Schema::Integer.new))
           struct.member(:memory_reservation, Schema::Nullable.new(Schema::Integer.new))
           struct.member(:links, Schema::UnorderedArray.new(Schema::String.new))
           struct.member(:port_mappings, Schema::UnorderedArray.new(port_mapping_schema))


### PR DESCRIPTION
I think memory parameter is optional both in the hako definition and the ECS task definition.

https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#standard_container_definition_params

ecs-agent seems to create a docker container with `Memory=0` via Docker Remote API if it's not given, which is the same as not passing `--memory` parameter to `docker run`.

https://github.com/aws/amazon-ecs-agent/blob/v1.17.1/agent/api/task.go#L481-L487

In addition to that, 628f661 appends the missing unit `M` to the value of --memory parameter.