### PR TITLE
Take memory_reservation into account when calculating required memory

### DIFF
--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -939,7 +939,7 @@ module Hako
 
       RUN_TASK_INTERVAL = 10
       def try_scale_out_with_sns(task_definition)
-        required_cpu, required_memory = task_definition.container_definitions.inject([0, 0]) { |(cpu, memory), d| [cpu + d.cpu, memory + d.memory] }
+        required_cpu, required_memory = task_definition.container_definitions.inject([0, 0]) { |(cpu, memory), d| [cpu + d.cpu, memory + (d.memory_reservation || d.memory)] }
         @hako_task_id ||= SecureRandom.uuid
         message = JSON.dump(
           group_name: @autoscaling_group_for_oneshot,
@@ -1022,7 +1022,7 @@ module Hako
       # @param [Array<Aws::ECS::Types::ContainerInstance>] container_instances
       # @return [Boolean]
       def has_capacity?(task_definition, container_instances)
-        required_cpu, required_memory = task_definition.container_definitions.inject([0, 0]) { |(cpu, memory), d| [cpu + d.cpu, memory + d.memory] }
+        required_cpu, required_memory = task_definition.container_definitions.inject([0, 0]) { |(cpu, memory), d| [cpu + d.cpu, memory + (d.memory_reservation || d.memory)] }
         container_instances.any? do |ci|
           cpu = ci.remaining_resources.find { |r| r.name == 'CPU' }.integer_value
           memory = ci.remaining_resources.find { |r| r.name == 'MEMORY' }.integer_value


### PR DESCRIPTION
If we specify `memory_reservation`, the value is subtracted from the available memory of the container instance instead of the value of `memory`.

https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#standard_container_definition_params