### PR TITLE
Support target tracking scaling policy

### DIFF
--- a/examples/hello-autoscaling.jsonnet
+++ b/examples/hello-autoscaling.jsonnet
@@ -46,6 +46,15 @@ local provide(name) = fileProvider(std.toString({ path: 'hello.env' }), name);
           metric_interval_upper_bound: 0,
           metric_aggregation_type: 'Average',
         },
+        // Adjust the numer of tasks to keep the metric close to the target value
+        {
+          policy_type: 'TargetTrackingScaling',
+          name: 'ecs-target-tracking-scaling-hello-autoscaling-service',
+          target_value: 50,
+          predefined_metric_type: 'ECSServiceAverageCPUUtilization',
+          scale_out_cooldown: 300,
+          scale_in_cooldown: 300,
+        },
       ],
     },
   },

--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -46,7 +46,7 @@ module Hako
         @dynamic_port_mapping = options.fetch('dynamic_port_mapping', @ecs_elb_options.nil?)
         @health_check_grace_period_seconds = options.fetch('health_check_grace_period_seconds', nil)
         if options.key?('autoscaling')
-          @autoscaling = EcsAutoscaling.new(options.fetch('autoscaling'), @region, dry_run: @dry_run)
+          @autoscaling = EcsAutoscaling.new(options.fetch('autoscaling'), @region, ecs_elb_client, dry_run: @dry_run)
         end
         @autoscaling_group_for_oneshot = options.fetch('autoscaling_group_for_oneshot', nil)
         @autoscaling_topic_for_oneshot = options.fetch('autoscaling_topic_for_oneshot', nil)

--- a/lib/hako/schedulers/ecs_autoscaling.rb
+++ b/lib/hako/schedulers/ecs_autoscaling.rb
@@ -78,9 +78,13 @@ module Hako
               }
               if policy.predefined_metric_type == 'ALBRequestCountPerTarget'
                 if service.load_balancers.empty? || service.load_balancers[0].target_group_arn.nil?
-                  raise Error.new('Target group must be attached to the ECS service')
+                  raise Error.new('Target group must be attached to the ECS service for predefined metric type ALBRequestCountPerTarget')
                 end
-                predefined_metric_specification[:resource_label] = target_group_resource_label
+                resource_label = target_group_resource_label
+                unless resource_label.start_with?('app/')
+                  raise Error.new("Load balancer type must be 'application' for predefined metric type ALBRequestCountPerTarget")
+                end
+                predefined_metric_specification[:resource_label] = resource_label
               end
               policy_params[:target_tracking_scaling_policy_configuration] = {
                 target_value: policy.target_value,

--- a/lib/hako/schedulers/ecs_autoscaling.rb
+++ b/lib/hako/schedulers/ecs_autoscaling.rb
@@ -2,14 +2,16 @@
 
 require 'aws-sdk-applicationautoscaling'
 require 'aws-sdk-cloudwatch'
+require 'aws-sdk-elasticloadbalancingv2'
 require 'hako'
 require 'hako/error'
 
 module Hako
   module Schedulers
     class EcsAutoscaling
-      def initialize(options, region, dry_run:)
+      def initialize(options, region, ecs_elb_client, dry_run:)
         @region = region
+        @ecs_elb_client = ecs_elb_client
         @dry_run = dry_run
         @role_arn = required_option(options, 'role_arn')
         @min_capacity = required_option(options, 'min_capacity')
@@ -44,17 +46,21 @@ module Hako
         @policies.each do |policy|
           Hako.logger.info("Configuring scaling policy #{policy.name}")
           if @dry_run
-            policy.alarms.each do |alarm_name|
-              Hako.logger.info("Configuring #{alarm_name}'s alarm_action")
+            if policy.policy_type == 'StepScaling'
+              policy.alarms.each do |alarm_name|
+                Hako.logger.info("Configuring #{alarm_name}'s alarm_action")
+              end
             end
           else
-            policy_arn = autoscaling_client.put_scaling_policy(
+            policy_params = {
               policy_name: policy.name,
               service_namespace: service_namespace,
               resource_id: resource_id,
               scalable_dimension: scalable_dimension,
-              policy_type: 'StepScaling',
-              step_scaling_policy_configuration: {
+              policy_type: policy.policy_type,
+            }
+            if policy.policy_type == 'StepScaling'
+              policy_params[:step_scaling_policy_configuration] = {
                 adjustment_type: policy.adjustment_type,
                 step_adjustments: [
                   {
@@ -65,16 +71,36 @@ module Hako
                 ],
                 cooldown: policy.cooldown,
                 metric_aggregation_type: policy.metric_aggregation_type,
-              },
-            ).policy_arn
+              }
+            else
+              predefined_metric_specification = {
+                predefined_metric_type: policy.predefined_metric_type,
+              }
+              if policy.predefined_metric_type == 'ALBRequestCountPerTarget'
+                if service.load_balancers.empty? || service.load_balancers[0].target_group_arn.nil?
+                  raise Error.new('Target group must be attached to the ECS service')
+                end
+                predefined_metric_specification[:resource_label] = target_group_resource_label
+              end
+              policy_params[:target_tracking_scaling_policy_configuration] = {
+                target_value: policy.target_value,
+                predefined_metric_specification: predefined_metric_specification,
+                scale_out_cooldown: policy.scale_out_cooldown,
+                scale_in_cooldown: policy.scale_in_cooldown,
+                disable_scale_in: policy.disable_scale_in,
+              }
+            end
+            policy_arn = autoscaling_client.put_scaling_policy(policy_params).policy_arn
 
-            alarms = cw_client.describe_alarms(alarm_names: policy.alarms).flat_map(&:metric_alarms).map { |a| [a.alarm_name, a] }.to_h
-            policy.alarms.each do |alarm_name|
-              alarm = alarms.fetch(alarm_name) { raise Error.new("Alarm #{alarm_name} does not exist") }
-              Hako.logger.info("Updating #{alarm_name}'s alarm_actions from #{alarm.alarm_actions} to #{[policy_arn]}")
-              params = PUT_METRIC_ALARM_OPTIONS.map { |key| [key, alarm.public_send(key)] }.to_h
-              params[:alarm_actions] = [policy_arn]
-              cw_client.put_metric_alarm(params)
+            if policy.policy_type == 'StepScaling'
+              alarms = cw_client.describe_alarms(alarm_names: policy.alarms).flat_map(&:metric_alarms).map { |a| [a.alarm_name, a] }.to_h
+              policy.alarms.each do |alarm_name|
+                alarm = alarms.fetch(alarm_name) { raise Error.new("Alarm #{alarm_name} does not exist") }
+                Hako.logger.info("Updating #{alarm_name}'s alarm_actions from #{alarm.alarm_actions} to #{[policy_arn]}")
+                params = PUT_METRIC_ALARM_OPTIONS.map { |key| [key, alarm.public_send(key)] }.to_h
+                params[:alarm_actions] = [policy_arn]
+                cw_client.put_metric_alarm(params)
+              end
             end
           end
         end
@@ -139,23 +165,50 @@ module Hako
         "service/#{service.cluster_arn.slice(%r{[^/]+\z}, 0)}/#{service.service_name}"
       end
 
+      # @return [String]
+      def target_group_resource_label
+        target_group = @ecs_elb_client.describe_target_group
+        load_balancer_arn = target_group.load_balancer_arns[0]
+        target_group_arn = target_group.target_group_arn
+        "#{load_balancer_arn.slice(%r{:loadbalancer/(.+)\z}, 1)}/#{target_group_arn.slice(/[^:]+\z/)}"
+      end
+
       class Policy
+        attr_reader :policy_type
         attr_reader :alarms, :cooldown, :adjustment_type, :scaling_adjustment, :metric_interval_lower_bound, :metric_interval_upper_bound, :metric_aggregation_type
+        attr_reader :target_value, :predefined_metric_type, :scale_out_cooldown, :scale_in_cooldown, :disable_scale_in
 
         # @param [Hash] options
         def initialize(options)
-          @alarms = required_option(options, 'alarms')
-          @cooldown = required_option(options, 'cooldown')
-          @adjustment_type = required_option(options, 'adjustment_type')
-          @scaling_adjustment = required_option(options, 'scaling_adjustment')
-          @metric_interval_lower_bound = options.fetch('metric_interval_lower_bound', nil)
-          @metric_interval_upper_bound = options.fetch('metric_interval_upper_bound', nil)
-          @metric_aggregation_type = required_option(options, 'metric_aggregation_type')
+          @policy_type = options.fetch('policy_type', 'StepScaling')
+          case @policy_type
+          when 'StepScaling'
+            @alarms = required_option(options, 'alarms')
+            @cooldown = required_option(options, 'cooldown')
+            @adjustment_type = required_option(options, 'adjustment_type')
+            @scaling_adjustment = required_option(options, 'scaling_adjustment')
+            @metric_interval_lower_bound = options.fetch('metric_interval_lower_bound', nil)
+            @metric_interval_upper_bound = options.fetch('metric_interval_upper_bound', nil)
+            @metric_aggregation_type = required_option(options, 'metric_aggregation_type')
+          when 'TargetTrackingScaling'
+            @name = required_option(options, 'name')
+            @target_value = required_option(options, 'target_value')
+            @predefined_metric_type = required_option(options, 'predefined_metric_type')
+            @scale_out_cooldown = options.fetch('scale_out_cooldown', nil)
+            @scale_in_cooldown = options.fetch('scale_in_cooldown', nil)
+            @disable_scale_in = options.fetch('disable_scale_in', nil)
+          else
+            raise Error.new("scheduler.autoscaling.policies.#{policy_type} must be either 'StepScaling' or 'TargetTrackingScaling'")
+          end
         end
 
         # @return [String]
         def name
-          alarms.join('-and-')
+          if policy_type == 'StepScaling'
+            alarms.join('-and-')
+          else
+            @name
+          end
         end
 
         private


### PR DESCRIPTION
I would like to add support for setting up auto scaling using target tracking scaling policies.

https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-autoscaling-targettracking.html

Note that tracking arbitrary CloudWatch metrics seems to be not available yet.

http://www.rubydoc.info/gems/aws-sdk-applicationautoscaling/1.7.0/Aws/ApplicationAutoScaling/Types/TargetTrackingScalingPolicyConfiguration