### PR TITLE
Show --memory-reservation in the dry-run output

### DIFF
--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -1049,6 +1049,9 @@ module Hako
         if definition[:memory]
           cmd << '--memory' << "#{definition[:memory]}M"
         end
+        if definition[:memory_reservation]
+          cmd << '--memory-reservation' << "#{definition[:memory_reservation]}M"
+        end
         definition.fetch(:links).each do |link|
           cmd << '--link' << link
         end


### PR DESCRIPTION
`memory_reservation` value is passed to Docker with the recent version of ecs-agent.