### PR TITLE
Run containers referenced by volumes_from on hako oneshot

### DIFF
--- a/lib/hako/definition_loader.rb
+++ b/lib/hako/definition_loader.rb
@@ -52,6 +52,10 @@ module Hako
             m = link.match(/\A([^:]+):([^:]+)\z/)
             names << (m ? m[1] : link)
           end
+
+          containers[name].volumes_from.each do |volumes_from|
+            names << volumes_from[:source_container]
+          end
         end
       end
       containers

--- a/spec/fixtures/yaml/default_with_volumes_from.yml
+++ b/spec/fixtures/yaml/default_with_volumes_from.yml
@@ -1,0 +1,15 @@
+app:
+  image: app-image
+  volumes_from:
+    - source_container: redis
+additional_containers:
+  redis:
+    image_tag: redis
+    volumes_from:
+      - source_container: memcached
+  memcached:
+    image_tag: memcached
+  fluentd:
+    image_tag: fluentd
+    volumes_from:
+      - source_container: redis

--- a/spec/hako/definition_loader_spec.rb
+++ b/spec/hako/definition_loader_spec.rb
@@ -46,5 +46,22 @@ RSpec.describe Hako::DefinitionLoader do
         end
       end
     end
+
+    context 'with volumes_from' do
+      let(:fixture_name) { 'default_with_volumes_from.yml' }
+
+      it 'loads all containers' do
+        containers = definition_loader.load('latest')
+        expect(containers.keys).to match_array(%w[app redis memcached fluentd])
+        expect(containers.values).to all(be_a(Hako::Container))
+      end
+
+      context 'with `with`' do
+        it 'loads specified definition and referenced containers' do
+          containers = definition_loader.load('latest', with: [])
+          expect(containers.keys).to match_array(%w[app redis memcached])
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Containers referenced by `volumes_from` from the specified containers have to be run along with them, otherwise ECS API fails with something like `Aws::ECS::Errors::ClientException: Invalid 'volumesFrom' setting. Unknown container: 'container'.`.