### PR TITLE
Show --volumes-from in dry-run output

### DIFF
--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -1076,6 +1076,9 @@ module Hako
             raise "Could not find volume #{source_volume}"
           end
         end
+        definition.fetch(:volumes_from).each do |volumes_from|
+          cmd << '--volumes-from' << "#{volumes_from.fetch(:source_container)}#{volumes_from[:read_only] ? ':ro' : ''}"
+        end
         if definition[:privileged]
           cmd << '--privileged'
         end


### PR DESCRIPTION
The documentations for this option are here:

- https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions-volumesfrom.html
- https://docs.docker.com/engine/reference/commandline/run/#mount-volumes-from-container---volumes-from