### PR TITLE
ecs: Expect empty volume definition in --dry-run

### DIFF
--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -1071,7 +1071,11 @@ module Hako
           source_volume = mount_point.fetch(:source_volume)
           v = @volumes[source_volume]
           if v
-            cmd << '--volume' << "#{v.fetch('source_path')}:#{mount_point.fetch(:container_path)}#{mount_point[:read_only] ? ':ro' : ''}"
+            # When source_path is not given, ECS agent adds a container for generating empty volume to share between containers
+            #   https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_data_volumes.html
+            #   (To provide nonpersistent empty data volumes for containers)
+            source_path = v.fetch('source_path', "/tmp/ephemeral_#{source_volume}")
+            cmd << '--volume' << "#{source_path}:#{mount_point.fetch(:container_path)}#{mount_point[:read_only] ? ':ro' : ''}"
           else
             raise "Could not find volume #{source_volume}"
           end


### PR DESCRIPTION
When volume `source_path` is not given, ECS agent adds a `emptyvolume` container to generate a nonpersistent empty volume then share them between containers.

`--dry-run` could fail because it expects source_path. This patch changes to give `/tmp/ephemeral_$name` as a source path instead when the path isn't given.

(To emulate the same behavior in command line requires creation of empty image and container, but this patch doesn't implement it because it is considered overkill)

- https://github.com/aws/amazon-ecs-agent/blob/3631cb9de33a569d16e7a19d77105beeef8160c2/agent/api/task/task.go#L249
- https://github.com/aws/amazon-ecs-agent/blob/3631cb9de33a569d16e7a19d77105beeef8160c2/agent/dockerclient/dockerapi/docker_client.go#L434
- https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_data_volumes.html
  - > To provide nonpersistent empty data volumes for containers