### PR TITLE
Support shared_memory_size parameter

### DIFF
--- a/lib/hako/container.rb
+++ b/lib/hako/container.rb
@@ -138,6 +138,8 @@ module Hako
 
         ret[:init_process_enabled] = conf.fetch('init_process_enabled', nil)
 
+        ret[:shared_memory_size] = conf.fetch('shared_memory_size', nil)
+
         ret
       end
     end

--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -1113,6 +1113,10 @@ module Hako
           if definition[:init_process_enabled]
             cmd << '--init'
           end
+
+          if definition[:linux_parameters][:shared_memory_size]
+            cmd << '--shm-size' << "#{definition[:linux_parameters][:shared_memory_size]}m"
+          end
         end
         definition.fetch(:volumes_from).each do |volumes_from|
           p volumes_from

--- a/lib/hako/schedulers/ecs_definition_comparator.rb
+++ b/lib/hako/schedulers/ecs_definition_comparator.rb
@@ -95,6 +95,7 @@ module Hako
           struct.member(:capabilities, Schema::Nullable.new(capabilities_schema))
           struct.member(:devices, Schema::Nullable.new(devices_schema))
           struct.member(:init_process_enabled, Schema::Nullable.new(Schema::Boolean.new))
+          struct.member(:shared_memory_size, Schema::Nullable.new(Schema::Integer.new))
         end
       end
 

--- a/spec/hako/schedulers/ecs_definition_comparator_spec.rb
+++ b/spec/hako/schedulers/ecs_definition_comparator_spec.rb
@@ -34,7 +34,8 @@ RSpec.describe Hako::Schedulers::EcsDefinitionComparator do
                 container_path: nil,
                 permissions: ['read']
               }
-            ]
+            ],
+            shared_memory_size: 128
           }
         }.merge(default_config)
       end
@@ -53,7 +54,8 @@ RSpec.describe Hako::Schedulers::EcsDefinitionComparator do
                 container_path: nil,
                 permissions: ['read']
               }
-            ]
+            ],
+            shared_memory_size: 128
           )
         }.merge(default_config))
       end


### PR DESCRIPTION
This adds support for the [newly introduced](https://aws.amazon.com/about-aws/whats-new/2018/03/amazon-ecs-adds-support-for-shm-size-and-tmpfs-parameters/) [`sharedMemorySize`](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_LinuxParameters.html#ECS-Type-LinuxParameters-sharedMemorySize) parameter, which corresponds to the [`--shm-size`](https://docs.docker.com/engine/reference/run/#runtime-constraints-on-resources) option of `docker run`.