### PR TITLE
Support tmpfs parameter

### DIFF
--- a/lib/hako/container.rb
+++ b/lib/hako/container.rb
@@ -159,6 +159,16 @@ module Hako
 
         ret[:shared_memory_size] = conf.fetch('shared_memory_size', nil)
 
+        if conf.key?('tmpfs')
+          ret[:tmpfs] = conf['tmpfs'].map do |t|
+            {
+              container_path: t.fetch('container_path'),
+              mount_options: t.fetch('mount_options', []),
+              size: t.fetch('size')
+            }
+          end
+        end
+
         ret
       end
     end

--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -1119,7 +1119,7 @@ module Hako
             cmd << '--shm-size' << "#{definition[:linux_parameters][:shared_memory_size]}m"
           end
 
-          definition[:linux_parameters][:tmpfs].each do |tmpfs|
+          definition[:linux_parameters].fetch(:tmpfs, []).each do |tmpfs|
             options = ["size=#{tmpfs[:size]}m"].concat(tmpfs[:mount_options])
             cmd << '--tmpfs' << "#{tmpfs[:container_path]}:#{options.join(',')}"
           end

--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -1118,6 +1118,11 @@ module Hako
           if definition[:linux_parameters][:shared_memory_size]
             cmd << '--shm-size' << "#{definition[:linux_parameters][:shared_memory_size]}m"
           end
+
+          definition[:linux_parameters][:tmpfs].each do |tmpfs|
+            options = ["size=#{tmpfs[:size]}m"].concat(tmpfs[:mount_options])
+            cmd << '--tmpfs' << "#{tmpfs[:container_path]}:#{options.join(',')}"
+          end
         end
         definition.fetch(:volumes_from).each do |volumes_from|
           p volumes_from

--- a/lib/hako/schedulers/ecs_definition_comparator.rb
+++ b/lib/hako/schedulers/ecs_definition_comparator.rb
@@ -107,6 +107,7 @@ module Hako
           struct.member(:devices, Schema::Nullable.new(devices_schema))
           struct.member(:init_process_enabled, Schema::Nullable.new(Schema::Boolean.new))
           struct.member(:shared_memory_size, Schema::Nullable.new(Schema::Integer.new))
+          struct.member(:tmpfs, Schema::Nullable.new(tmpfs_schema))
         end
       end
 
@@ -127,6 +128,16 @@ module Hako
           struct.member(:container_path, Schema::Nullable.new(Schema::String.new))
           struct.member(:permissions, Schema::UnorderedArray.new(Schema::String.new))
         end
+      end
+
+      def tmpfs_schema
+        Schema::UnorderedArray.new(
+          Schema::Structure.new.tap do |struct|
+            struct.member(:container_path, Schema::String.new)
+            struct.member(:mount_options, Schema::UnorderedArray.new(Schema::String.new))
+            struct.member(:size, Schema::Integer.new)
+          end
+        )
       end
 
       def extra_hosts_schema

--- a/spec/hako/schedulers/ecs_definition_comparator_spec.rb
+++ b/spec/hako/schedulers/ecs_definition_comparator_spec.rb
@@ -35,7 +35,14 @@ RSpec.describe Hako::Schedulers::EcsDefinitionComparator do
                 permissions: ['read']
               }
             ],
-            shared_memory_size: 128
+            shared_memory_size: 128,
+            tmpfs: [
+              {
+                container_path: '/tmp',
+                mount_options: ['defaults'],
+                size: 128
+              }
+            ]
           }
         }.merge(default_config)
       end
@@ -55,7 +62,14 @@ RSpec.describe Hako::Schedulers::EcsDefinitionComparator do
                 permissions: ['read']
               }
             ],
-            shared_memory_size: 128
+            shared_memory_size: 128,
+            tmpfs: [
+              {
+                container_path: '/tmp',
+                mount_options: ['defaults'],
+                size: 128
+              }
+            ]
           )
         }.merge(default_config))
       end


### PR DESCRIPTION
This adds support for the [newly introduced](https://aws.amazon.com/about-aws/whats-new/2018/03/amazon-ecs-adds-support-for-shm-size-and-tmpfs-parameters/) [`tmpfs`](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_LinuxParameters.html#ECS-Type-LinuxParameters-tmpfs) parameter, which corresponds to the [`--tmpfs`](https://docs.docker.com/engine/reference/run/#tmpfs-mount-tmpfs-filesystems) option of `docker run`.