### PR TITLE
Support docker_volume_configuration parameter

### DIFF
--- a/hako.gemspec
+++ b/hako.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'aws-sdk-cloudwatch'
   spec.add_dependency 'aws-sdk-cloudwatchlogs'
   spec.add_dependency 'aws-sdk-ec2'
-  spec.add_dependency 'aws-sdk-ecs', '>= 1.4.0'
+  spec.add_dependency 'aws-sdk-ecs', '>= 1.7.0'
   spec.add_dependency 'aws-sdk-elasticloadbalancing'
   spec.add_dependency 'aws-sdk-elasticloadbalancingv2'
   spec.add_dependency 'aws-sdk-s3'

--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -1063,7 +1063,7 @@ module Hako
       # @param [Hash] definition
       # @return [nil]
       def print_volume_definition_in_cli_format(definition)
-        return unless definition.dig(:docker_volume_configuration, :autoprovision) == true
+        return if definition.dig(:docker_volume_configuration, :autoprovision)
         # From version 1.20.0 of ECS agent, a local volume is provisioned when
         # 'host' is specified without 'source_path'.
         return if definition.dig(:host, :source_path)

--- a/lib/hako/schedulers/ecs_volume_comparator.rb
+++ b/lib/hako/schedulers/ecs_volume_comparator.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'hako/schema'
+
+module Hako
+  module Schedulers
+    class EcsVolumeComparator
+      # @param [Hash] expected_volume
+      def initialize(expected_volume)
+        @expected_volume = expected_volume
+        @schema = volume_schema
+      end
+
+      # @param [Aws::ECS::Types::Volume] actual_volume
+      # @return [Boolean]
+      def different?(actual_volume)
+        !@schema.same?(actual_volume.to_h, @expected_volume)
+      end
+
+      private
+
+      def volume_schema
+        Schema::Structure.new.tap do |struct|
+          struct.member(:docker_volume_configuration, Schema::Nullable.new(docker_volume_configuration_schema))
+          struct.member(:host, Schema::Nullable.new(host_schema))
+          struct.member(:name, Schema::String.new)
+        end
+      end
+
+      def docker_volume_configuration_schema
+        Schema::Structure.new.tap do |struct|
+          struct.member(:autoprovision, Schema::Nullable.new(Schema::Boolean.new))
+          struct.member(:driver, Schema::WithDefault.new(Schema::String.new, 'local'))
+          struct.member(:driver_opts, Schema::Nullable.new(Schema::Table.new(Schema::String.new, Schema::String.new)))
+          struct.member(:labels, Schema::Nullable.new(Schema::Table.new(Schema::String.new, Schema::String.new)))
+          struct.member(:scope, Schema::WithDefault.new(Schema::String.new, 'task'))
+        end
+      end
+
+      def host_schema
+        Schema::Structure.new.tap do |struct|
+          struct.member(:source_path, Schema::Nullable.new(Schema::String.new))
+        end
+      end
+    end
+  end
+end

--- a/spec/hako/schedulers/ecs_volume_comparator_spec.rb
+++ b/spec/hako/schedulers/ecs_volume_comparator_spec.rb
@@ -11,11 +11,11 @@ RSpec.describe Hako::Schedulers::EcsVolumeComparator do
       docker_volume_configuration: {
         autoprovision: false,
         driver_opts: {
-          type: 'tmpfs',
-          device: 'tmpfs',
+          'type' => 'tmpfs',
+          'device' => 'tmpfs',
         },
         labels: {
-          foo: 'bar',
+          'foo' => 'bar',
         },
       },
       host: {
@@ -30,11 +30,11 @@ RSpec.describe Hako::Schedulers::EcsVolumeComparator do
         autoprovision: false,
         driver: 'local',
         driver_opts: {
-          type: 'tmpfs',
-          device: 'tmpfs',
+          'type' => 'tmpfs',
+          'device' => 'tmpfs',
         },
         labels: {
-          foo: 'bar',
+          'foo' => 'bar',
         },
         scope: 'task',
       ),
@@ -54,7 +54,7 @@ RSpec.describe Hako::Schedulers::EcsVolumeComparator do
 
     context 'when some parameters differ' do
       before do
-        actual_volume.name = 'bar'
+        actual_volume.docker_volume_configuration.labels['foo'] = 'baz'
       end
 
       it 'returns true' do

--- a/spec/hako/schedulers/ecs_volume_comparator_spec.rb
+++ b/spec/hako/schedulers/ecs_volume_comparator_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'hako/schedulers/ecs_volume_comparator'
+require 'aws-sdk-ecs'
+
+RSpec.describe Hako::Schedulers::EcsVolumeComparator do
+  let(:comparator) { described_class.new(expected_volume) }
+  let(:expected_volume) do
+    {
+      docker_volume_configuration: {
+        autoprovision: false,
+        driver_opts: {
+          type: 'tmpfs',
+          device: 'tmpfs',
+        },
+        labels: {
+          foo: 'bar',
+        },
+      },
+      host: {
+        source_path: '/tmp',
+      },
+      name: 'foo',
+    }
+  end
+  let(:actual_volume) do
+    Aws::ECS::Types::Volume.new(
+      docker_volume_configuration: Aws::ECS::Types::DockerVolumeConfiguration.new(
+        autoprovision: false,
+        driver: 'local',
+        driver_opts: {
+          type: 'tmpfs',
+          device: 'tmpfs',
+        },
+        labels: {
+          foo: 'bar',
+        },
+        scope: 'task',
+      ),
+      host: Aws::ECS::Types::HostVolumeProperties.new(
+        source_path: '/tmp',
+      ),
+      name: 'foo',
+    )
+  end
+
+  describe '#different?' do
+    context 'when same' do
+      it 'returns false' do
+        expect(comparator).to_not be_different(actual_volume)
+      end
+    end
+
+    context 'when some parameters differ' do
+      before do
+        actual_volume.name = 'bar'
+      end
+
+      it 'returns true' do
+        expect(comparator).to be_different(actual_volume)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds support for the [newly introduced](https://aws.amazon.com/about-aws/whats-new/2018/08/amazon-ecs-now-supports-docker-volume-and-volume-plugins/) [`docker_volume_configuration`](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DockerVolumeConfiguration.html) parameter, which configures a Docker volume to use with a task.

Note that this parameter requires ECS agent 1.20.0 or later.