### PR TITLE
Support readonly_root_filesystem parameter

### DIFF
--- a/lib/hako/container.rb
+++ b/lib/hako/container.rb
@@ -29,6 +29,7 @@ module Hako
       command
       user
       privileged
+      readonly_root_filesystem
     ].each do |name|
       define_method(name) do
         @definition[name]

--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -600,6 +600,7 @@ module Hako
           health_check: container.health_check,
           ulimits: container.ulimits,
           extra_hosts: container.extra_hosts,
+          readonly_root_filesystem: container.readonly_root_filesystem,
         }
       end
 
@@ -1174,6 +1175,9 @@ module Hako
         end
         if definition[:user]
           cmd << '--user' << definition[:user]
+        end
+        if definition[:readonly_root_filesystem]
+          cmd << '--read-only'
         end
 
         cmd << "\\\n  "

--- a/lib/hako/schedulers/ecs_definition_comparator.rb
+++ b/lib/hako/schedulers/ecs_definition_comparator.rb
@@ -39,6 +39,7 @@ module Hako
           struct.member(:ulimits, Schema::Nullable.new(ulimits_schema))
           struct.member(:extra_hosts, Schema::Nullable.new(extra_hosts_schema))
           struct.member(:linux_parameters, Schema::Nullable.new(linux_parameters_schema))
+          struct.member(:readonly_root_filesystem, Schema::Nullable.new(Schema::Boolean.new))
         end
       end
 

--- a/spec/hako/schedulers/ecs_spec.rb
+++ b/spec/hako/schedulers/ecs_spec.rb
@@ -81,6 +81,7 @@ RSpec.describe Hako::Schedulers::Ecs do
         health_check: nil,
         ulimits: nil,
         extra_hosts: nil,
+        readonly_root_filesystem: nil,
       }],
       volumes: [],
       requires_compatibilities: nil,


### PR DESCRIPTION
I would like to add support for [readonly_root_filesystem](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDefinition.html#ECS-Type-ContainerDefinition-readonlyRootFilesystem) parameter, which corresponds to the `--read-only` option of `docker run`. 