### PR TITLE
Support docker_security_options parameter

### DIFF
--- a/lib/hako/container.rb
+++ b/lib/hako/container.rb
@@ -30,6 +30,7 @@ module Hako
       user
       privileged
       readonly_root_filesystem
+      docker_security_options
     ].each do |name|
       define_method(name) do
         @definition[name]
@@ -212,6 +213,7 @@ module Hako
         'port_mappings' => [],
         'volumes_from' => [],
         'privileged' => false,
+        'docker_security_options' => [],
       }
     end
 

--- a/lib/hako/container.rb
+++ b/lib/hako/container.rb
@@ -213,7 +213,6 @@ module Hako
         'port_mappings' => [],
         'volumes_from' => [],
         'privileged' => false,
-        'docker_security_options' => [],
       }
     end
 

--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -1180,7 +1180,7 @@ module Hako
         if definition[:readonly_root_filesystem]
           cmd << '--read-only'
         end
-        definition.fetch(:docker_security_options).each do |docker_security_option|
+        (definition[:docker_security_options] || []).each do |docker_security_option|
           cmd << '--security-opt' << docker_security_option
         end
 

--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -601,6 +601,7 @@ module Hako
           ulimits: container.ulimits,
           extra_hosts: container.extra_hosts,
           readonly_root_filesystem: container.readonly_root_filesystem,
+          docker_security_options: container.docker_security_options,
         }
       end
 
@@ -1178,6 +1179,9 @@ module Hako
         end
         if definition[:readonly_root_filesystem]
           cmd << '--read-only'
+        end
+        definition.fetch(:docker_security_options).each do |docker_security_option|
+          cmd << '--security-opt' << docker_security_option
         end
 
         cmd << "\\\n  "

--- a/lib/hako/schedulers/ecs_definition_comparator.rb
+++ b/lib/hako/schedulers/ecs_definition_comparator.rb
@@ -40,6 +40,7 @@ module Hako
           struct.member(:extra_hosts, Schema::Nullable.new(extra_hosts_schema))
           struct.member(:linux_parameters, Schema::Nullable.new(linux_parameters_schema))
           struct.member(:readonly_root_filesystem, Schema::Nullable.new(Schema::Boolean.new))
+          struct.member(:docker_security_options, Schema::UnorderedArray.new(Schema::String.new))
         end
       end
 

--- a/lib/hako/schedulers/ecs_definition_comparator.rb
+++ b/lib/hako/schedulers/ecs_definition_comparator.rb
@@ -40,7 +40,7 @@ module Hako
           struct.member(:extra_hosts, Schema::Nullable.new(extra_hosts_schema))
           struct.member(:linux_parameters, Schema::Nullable.new(linux_parameters_schema))
           struct.member(:readonly_root_filesystem, Schema::Nullable.new(Schema::Boolean.new))
-          struct.member(:docker_security_options, Schema::UnorderedArray.new(Schema::String.new))
+          struct.member(:docker_security_options, Schema::Nullable.new(Schema::UnorderedArray.new(Schema::String.new)))
         end
       end
 

--- a/spec/hako/schedulers/ecs_definition_comparator_spec.rb
+++ b/spec/hako/schedulers/ecs_definition_comparator_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe Hako::Schedulers::EcsDefinitionComparator do
         mount_points: [],
         port_mappings: [],
         volumes_from: [],
-        docker_security_options: [],
       }
     end
 

--- a/spec/hako/schedulers/ecs_definition_comparator_spec.rb
+++ b/spec/hako/schedulers/ecs_definition_comparator_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Hako::Schedulers::EcsDefinitionComparator do
         mount_points: [],
         port_mappings: [],
         volumes_from: [],
+        docker_security_options: [],
       }
     end
 

--- a/spec/hako/schedulers/ecs_spec.rb
+++ b/spec/hako/schedulers/ecs_spec.rb
@@ -82,6 +82,7 @@ RSpec.describe Hako::Schedulers::Ecs do
         ulimits: nil,
         extra_hosts: nil,
         readonly_root_filesystem: nil,
+        docker_security_options: [],
       }],
       volumes: [],
       requires_compatibilities: nil,
@@ -115,6 +116,7 @@ RSpec.describe Hako::Schedulers::Ecs do
       mount_points: [],
       privileged: false,
       volumes_from: [],
+      docker_security_options: [],
     )
   end
 

--- a/spec/hako/schedulers/ecs_spec.rb
+++ b/spec/hako/schedulers/ecs_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Hako::Schedulers::Ecs do
         ulimits: nil,
         extra_hosts: nil,
         readonly_root_filesystem: nil,
-        docker_security_options: [],
+        docker_security_options: nil,
       }],
       volumes: [],
       requires_compatibilities: nil,
@@ -116,7 +116,6 @@ RSpec.describe Hako::Schedulers::Ecs do
       mount_points: [],
       privileged: false,
       volumes_from: [],
-      docker_security_options: [],
     )
   end
 


### PR DESCRIPTION
I would like to add support for [docker_security_options](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDefinition.html#ECS-Type-ContainerDefinition-dockerSecurityOptions) parameter, which corresponds to the `--security-opt` option of `docker run`. 