### PR TITLE
Support ssl_policy option in elb_v2

### DIFF
--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -924,7 +924,7 @@ module Hako
         end
       end
 
-      TASK_ID_RE = /\(task ([\h-]+)\)\.\z/
+      TASK_ID_RE = /\(task ([\h-]+)\)\.\z/.freeze
       # @param [String] message
       # @return [String, nil]
       def extract_task_id(message)

--- a/lib/hako/schedulers/ecs_elb_v2.rb
+++ b/lib/hako/schedulers/ecs_elb_v2.rb
@@ -108,6 +108,7 @@ module Hako
             load_balancer_arn: load_balancer.load_balancer_arn,
             protocol: l.fetch('protocol'),
             port: l.fetch('port'),
+            ssl_policy: l['ssl_policy'],
             default_actions: [{ type: 'forward', target_group_arn: target_group.target_group_arn }],
           }
           certificate_arn = l.fetch('certificate_arn', nil)

--- a/lib/hako/schedulers/ecs_elb_v2.rb
+++ b/lib/hako/schedulers/ecs_elb_v2.rb
@@ -142,6 +142,24 @@ module Hako
           end
         end
 
+        new_listeners = @elb_v2_config.fetch('listeners').map { |l| { 'port' => l['port'], 'ssl_policy' => l['ssl_policy'] } }
+        if load_balancer
+          current_listeners = elb_client.describe_listeners(load_balancer_arn: load_balancer.load_balancer_arn).flat_map do |page|
+            page.listeners.map { |l| { 'port' => l[:port], 'ssl_policy' => l[:ssl_policy], 'listener_arn' => l[:listener_arn] } }
+          end
+          new_listeners.each do |new_listener|
+            current_listener = current_listeners.find { |l| l['port'] == new_listener['port'] }
+            if current_listener && new_listener['ssl_policy'] && new_listener['ssl_policy'] != current_listener['ssl_policy']
+              if @dry_run
+                Hako.logger.info("elb_client.modify_listener(listener_arn: #{current_listener['listener_arn']}, ssl_policy: #{new_listener['ssl_policy']}) (dry-run)")
+              else
+                Hako.logger.info("Updating ELBv2 listener #{new_listener['port']} ssl_policy to #{new_listener['ssl_policy']}")
+                elb_client.modify_listener(listener_arn: current_listener['listener_arn'], ssl_policy: new_listener['ssl_policy'])
+              end
+            end
+          end
+        end
+
         if @elb_v2_config.key?('load_balancer_attributes')
           attributes = @elb_v2_config.fetch('load_balancer_attributes').map { |key, value| { key: key, value: value } }
           if @dry_run

--- a/spec/fixtures/jsonnet/ecs-elbv2.jsonnet
+++ b/spec/fixtures/jsonnet/ecs-elbv2.jsonnet
@@ -16,6 +16,7 @@
         {
           port: 443,
           protocol: 'HTTPS',
+          ssl_policy: 'ELBSecurityPolicy-2016-08',
           certificate_arn: 'arn:aws:acm:ap-northeast-1:012345678901:certificate/01234567-89ab-cdef-0123-456789abcdef',
         },
       ],

--- a/spec/hako/schedulers/ecs_spec.rb
+++ b/spec/hako/schedulers/ecs_spec.rb
@@ -312,6 +312,7 @@ RSpec.describe Hako::Schedulers::Ecs do
           load_balancer_arn: load_balancer_arn,
           protocol: 'HTTP',
           port: 80,
+          ssl_policy: nil,
           default_actions: [{ type: 'forward', target_group_arn: target_group_arn }],
         ).and_return(Aws::ElasticLoadBalancingV2::Types::CreateListenerOutput.new(
           listeners: [Aws::ElasticLoadBalancingV2::Types::Listener.new(listener_arn: "arn:aws:elasticloadbalancing:ap-northeast-1:012345678901:listener/app/#{app.id}/0123456789abcdef/0123456789abcdef")],
@@ -320,6 +321,7 @@ RSpec.describe Hako::Schedulers::Ecs do
           load_balancer_arn: load_balancer_arn,
           protocol: 'HTTPS',
           port: 443,
+          ssl_policy: 'ELBSecurityPolicy-2016-08',
           default_actions: [{ type: 'forward', target_group_arn: target_group_arn }],
           certificates: [{ certificate_arn: 'arn:aws:acm:ap-northeast-1:012345678901:certificate/01234567-89ab-cdef-0123-456789abcdef' }],
         ).and_return(Aws::ElasticLoadBalancingV2::Types::CreateListenerOutput.new(


### PR DESCRIPTION
I would like to add/modify ssl_policy options when create or update ALB attributes on deploy.

I hope that this change will help us to manage security options of ALB by hako.

https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html

@eagletmt Please review 🙏 