### PR TITLE
Enable to specify ELB or ELBv2 (and target group) name

### DIFF
--- a/lib/hako/schedulers/ecs_elb.rb
+++ b/lib/hako/schedulers/ecs_elb.rb
@@ -99,7 +99,7 @@ module Hako
 
       # @return [String]
       def name
-        "hako-#{@app_id}"
+        @elb_config.fetch('elb_name', "hako-#{@app_id}")
       end
 
       # @return [Hash]

--- a/lib/hako/schedulers/ecs_elb_v2.rb
+++ b/lib/hako/schedulers/ecs_elb_v2.rb
@@ -38,7 +38,7 @@ module Hako
 
       # @return [Aws::ElasticLoadBalancingV2::Types::TargetGroup]
       def describe_target_group
-        elb_client.describe_target_groups(names: [elb_name]).target_groups[0]
+        elb_client.describe_target_groups(names: [target_group_name]).target_groups[0]
       rescue Aws::ElasticLoadBalancingV2::Errors::TargetGroupNotFound
         nil
       end
@@ -82,7 +82,7 @@ module Hako
           elb_type = @elb_v2_config.fetch('type', nil)
           target_group = if elb_type == 'network'
                            elb_client.create_target_group(
-                             name: elb_name,
+                             name: target_group_name,
                              port: 80,
                              protocol: 'TCP',
                              vpc_id: @elb_v2_config.fetch('vpc_id'),
@@ -90,7 +90,7 @@ module Hako
                            ).target_groups[0]
                          else
                            elb_client.create_target_group(
-                             name: elb_name,
+                             name: target_group_name,
                              port: 80,
                              protocol: 'HTTP',
                              vpc_id: @elb_v2_config.fetch('vpc_id'),

--- a/lib/hako/schedulers/ecs_elb_v2.rb
+++ b/lib/hako/schedulers/ecs_elb_v2.rb
@@ -233,7 +233,7 @@ module Hako
 
       # @return [String]
       def name
-        "hako-#{@app_id}"
+        @elb_v2_config.fetch('elb_name', "hako-#{@app_id}")
       end
 
       # @return [Hash]

--- a/lib/hako/schedulers/ecs_elb_v2.rb
+++ b/lib/hako/schedulers/ecs_elb_v2.rb
@@ -236,6 +236,11 @@ module Hako
         @elb_v2_config.fetch('elb_name', "hako-#{@app_id}")
       end
 
+      # @return [String]
+      def target_group_name
+        @elb_v2_config.fetch('target_group_name', "hako-#{@app_id}")
+      end
+
       # @return [Hash]
       def load_balancer_params_for_service
         {

--- a/lib/hako/schedulers/ecs_elb_v2.rb
+++ b/lib/hako/schedulers/ecs_elb_v2.rb
@@ -31,14 +31,14 @@ module Hako
 
       # @return [Aws::ElasticLoadBalancingV2::Types::LoadBalancer]
       def describe_load_balancer
-        elb_client.describe_load_balancers(names: [name]).load_balancers[0]
+        elb_client.describe_load_balancers(names: [elb_name]).load_balancers[0]
       rescue Aws::ElasticLoadBalancingV2::Errors::LoadBalancerNotFound
         nil
       end
 
       # @return [Aws::ElasticLoadBalancingV2::Types::TargetGroup]
       def describe_target_group
-        elb_client.describe_target_groups(names: [name]).target_groups[0]
+        elb_client.describe_target_groups(names: [elb_name]).target_groups[0]
       rescue Aws::ElasticLoadBalancingV2::Errors::TargetGroupNotFound
         nil
       end
@@ -57,7 +57,7 @@ module Hako
           elb_type = @elb_v2_config.fetch('type', nil)
           if elb_type == 'network'
             load_balancer = elb_client.create_load_balancer(
-              name: name,
+              name: elb_name,
               subnets: @elb_v2_config.fetch('subnets'),
               scheme: @elb_v2_config.fetch('scheme', nil),
               type: 'network',
@@ -66,7 +66,7 @@ module Hako
             Hako.logger.info "Created ELBv2(NLB) #{load_balancer.dns_name}"
           else
             load_balancer = elb_client.create_load_balancer(
-              name: name,
+              name: elb_name,
               subnets: @elb_v2_config.fetch('subnets'),
               security_groups: @elb_v2_config.fetch('security_groups'),
               scheme: @elb_v2_config.fetch('scheme', nil),
@@ -82,7 +82,7 @@ module Hako
           elb_type = @elb_v2_config.fetch('type', nil)
           target_group = if elb_type == 'network'
                            elb_client.create_target_group(
-                             name: name,
+                             name: elb_name,
                              port: 80,
                              protocol: 'TCP',
                              vpc_id: @elb_v2_config.fetch('vpc_id'),
@@ -90,7 +90,7 @@ module Hako
                            ).target_groups[0]
                          else
                            elb_client.create_target_group(
-                             name: name,
+                             name: elb_name,
                              port: 80,
                              protocol: 'HTTP',
                              vpc_id: @elb_v2_config.fetch('vpc_id'),
@@ -203,7 +203,7 @@ module Hako
             Hako.logger.info "Deleted ELBv2 #{load_balancer.load_balancer_arn}"
           end
         else
-          Hako.logger.info "ELBv2 #{name} doesn't exist"
+          Hako.logger.info "ELBv2 #{elb_name} doesn't exist"
         end
 
         target_group = describe_target_group
@@ -232,7 +232,7 @@ module Hako
       end
 
       # @return [String]
-      def name
+      def elb_name
         @elb_v2_config.fetch('elb_name', "hako-#{@app_id}")
       end
 


### PR DESCRIPTION
ELB and ELBv2 name is fixed with the `hako-` prefix.
I'd like to customize the ELB name because I want to use hako deploy in environment that ELB already exists and not want to create new ELB with `hako-` prefix.

This PR is that the ELB or ELBv2 and target group name can be included with optional in settings.