### PR TITLE
Support essential parameter

### DIFF
--- a/lib/hako/container.rb
+++ b/lib/hako/container.rb
@@ -26,6 +26,7 @@ module Hako
       memory
       memory_reservation
       links
+      essential
       command
       user
       privileged
@@ -221,6 +222,7 @@ module Hako
         'env' => {},
         'docker_labels' => {},
         'links' => [],
+        'essential' => true,
         'mount_points' => [],
         'port_mappings' => [],
         'volumes_from' => [],

--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -599,7 +599,7 @@ module Hako
           memory_reservation: container.memory_reservation,
           links: container.links,
           port_mappings: container.port_mappings,
-          essential: true,
+          essential: container.essential,
           environment: environment,
           secrets: container.secrets,
           docker_labels: container.docker_labels,

--- a/lib/hako/schedulers/ecs_definition_comparator.rb
+++ b/lib/hako/schedulers/ecs_definition_comparator.rb
@@ -26,6 +26,7 @@ module Hako
           struct.member(:memory, Schema::Nullable.new(Schema::Integer.new))
           struct.member(:memory_reservation, Schema::Nullable.new(Schema::Integer.new))
           struct.member(:links, Schema::UnorderedArray.new(Schema::String.new))
+          struct.member(:essential, Schema::Boolean.new)
           struct.member(:port_mappings, Schema::UnorderedArray.new(port_mapping_schema))
           struct.member(:environment, Schema::UnorderedArray.new(environment_schema))
           struct.member(:secrets, Schema::Nullable.new(Schema::UnorderedArray.new(secrets_schema)))

--- a/spec/hako/schedulers/ecs_spec.rb
+++ b/spec/hako/schedulers/ecs_spec.rb
@@ -111,6 +111,7 @@ RSpec.describe Hako::Schedulers::Ecs do
       cpu: 32,
       memory: 64,
       links: [],
+      essential: true,
       port_mappings: [],
       environment: [],
       docker_labels: { 'cc.wanko.hako.version' => Hako::VERSION },


### PR DESCRIPTION
It would be helpful if I could set [essential](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDefinition.html#ECS-Type-ContainerDefinition-essential) parameter of a sidecar container to false in a certain case so I don't have to arrange a command to keep it running.

ECS API

- sets the essential parameter to true if it is not specified
- returns `Aws::ECS::Errors::ClientException: Task definition doesn't have any essential container.` if there is no essential container in a task definition.