### PR TITLE
Stop trying to deregister scalable target on hako remove

### DIFF
--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -303,9 +303,6 @@ module Hako
             ecs_client.delete_service(cluster: service.cluster_arn, service: service.service_arn)
             Hako.logger.info "#{service.service_arn} is deleted"
           end
-          if @autoscaling
-            @autoscaling.remove(service)
-          end
         else
           puts "Service #{@app_id} doesn't exist"
         end

--- a/lib/hako/schedulers/ecs_autoscaling.rb
+++ b/lib/hako/schedulers/ecs_autoscaling.rb
@@ -115,24 +115,6 @@ module Hako
 
       # @param [Aws::ECS::Types::Service] service
       # @return [nil]
-      def remove(service)
-        resource_id = service_resource_id(service)
-        service_namespace = 'ecs'
-        scalable_dimension = 'ecs:service:DesiredCount'
-
-        Hako.logger.info("Deregister scalable target #{resource_id} and its policies")
-        unless @dry_run
-          begin
-            autoscaling_client.deregister_scalable_target(service_namespace: service_namespace, resource_id: resource_id, scalable_dimension: scalable_dimension)
-          rescue Aws::ApplicationAutoScaling::Errors::ObjectNotFoundException => e
-            Hako.logger.warn(e)
-          end
-        end
-        nil
-      end
-
-      # @param [Aws::ECS::Types::Service] service
-      # @return [nil]
       def status(service)
         resource_id = service_resource_id(service)
         service_namespace = 'ecs'


### PR DESCRIPTION
#deregister_scalable_target always ends up with ObjectNotFoundException
because when a service is deleted, scalable targets and scaling policies
associated with it get deregistered/deleted along with the service.