### PR TITLE
Update health_check_grace_period_seconds when changed

### DIFF
--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -45,7 +45,9 @@ module Hako
           @ecs_elb_v2_options['target_type'] = 'ip'
         end
         @dynamic_port_mapping = options.fetch('dynamic_port_mapping', @ecs_elb_options.nil?)
-        @health_check_grace_period_seconds = options.fetch('health_check_grace_period_seconds', nil)
+        @health_check_grace_period_seconds = options.fetch('health_check_grace_period_seconds') do
+          @ecs_elb_options || @ecs_elb_v2_options ? 0 : nil
+        end
         if options.key?('autoscaling')
           @autoscaling = EcsAutoscaling.new(options.fetch('autoscaling'), @region, ecs_elb_client, dry_run: @dry_run)
         end

--- a/lib/hako/schedulers/ecs_service_comparator.rb
+++ b/lib/hako/schedulers/ecs_service_comparator.rb
@@ -25,6 +25,7 @@ module Hako
           struct.member(:deployment_configuration, Schema::WithDefault.new(deployment_configuration_schema, default_configuration))
           struct.member(:platform_version, Schema::String.new)
           struct.member(:network_configuration, Schema::Nullable.new(network_configuration_schema))
+          struct.member(:health_check_grace_period_seconds, Schema::Nullable.new(Schema::Integer.new))
         end
       end
 

--- a/spec/hako/schedulers/ecs_spec.rb
+++ b/spec/hako/schedulers/ecs_spec.rb
@@ -330,6 +330,7 @@ RSpec.describe Hako::Schedulers::Ecs do
         )).once
         expect(ecs_client).to receive(:create_service).with(create_service_params.merge(
           task_definition: task_definition_arn,
+          health_check_grace_period_seconds: 0,
           load_balancers: [{
             target_group_arn: target_group_arn,
             container_name: 'front',
@@ -341,7 +342,10 @@ RSpec.describe Hako::Schedulers::Ecs do
             placement_strategy: [],
           ),
         )).once
-        expect(ecs_client).to receive(:update_service).with(update_service_params.merge(task_definition: task_definition_arn)).and_return(Aws::ECS::Types::UpdateServiceResponse.new(
+        expect(ecs_client).to receive(:update_service).with(update_service_params.merge(
+          task_definition: task_definition_arn,
+          health_check_grace_period_seconds: 0,
+        )).and_return(Aws::ECS::Types::UpdateServiceResponse.new(
           service: Aws::ECS::Types::Service.new(
             cluster_arn: cluster_arn,
             service_arn: service_arn,


### PR DESCRIPTION
When health_check_grace_period_seconds is not specified, ECS API appears
to set it to 0 if a service is configured to use a load balancer,
otherwise set it to nil.

It is not allowed to set health_check_grace_period_seconds on a service
without load balancer.