### PR TITLE
Avoid updating service when platform_version is not specified

### DIFF
--- a/lib/hako/schedulers/ecs_service_comparator.rb
+++ b/lib/hako/schedulers/ecs_service_comparator.rb
@@ -23,7 +23,7 @@ module Hako
           struct.member(:desired_count, Schema::Integer.new)
           struct.member(:task_definition, Schema::String.new)
           struct.member(:deployment_configuration, Schema::WithDefault.new(deployment_configuration_schema, default_configuration))
-          struct.member(:platform_version, Schema::String.new)
+          struct.member(:platform_version, Schema::WithDefault.new(Schema::String.new, 'LATEST'))
           struct.member(:network_configuration, Schema::Nullable.new(network_configuration_schema))
           struct.member(:health_check_grace_period_seconds, Schema::Nullable.new(Schema::Integer.new))
         end


### PR DESCRIPTION
platform_version is set to LATEST if it is not specified.