### PR TITLE
Support Service Discovery

### DIFF
--- a/examples/hello-service-discovery.jsonnet
+++ b/examples/hello-service-discovery.jsonnet
@@ -1,0 +1,49 @@
+local fileProvider = std.native('provide.file');
+local provide(name) = fileProvider(std.toString({ path: 'hello.env' }), name);
+
+{
+  scheduler: {
+    type: 'ecs',
+    region: 'ap-northeast-1',
+    cluster: 'eagletmt',
+    desired_count: 2,
+    role: 'ecsServiceRole',
+    service_discovery: [
+      {
+        container_name: 'app',
+        container_port: 80,
+        service: {
+          name: 'hello-service-discovery',
+          namespace_id: 'ns-XXXXXXXXXXXXXXXX',
+          dns_config: {
+            dns_records: [
+              {
+                type: 'SRV',
+                ttl: 60,
+              },
+            ],
+          },
+          health_check_custom_config: {
+            failure_threshold: 1,
+          },
+        },
+      },
+    ],
+  },
+  app: {
+    image: 'ryotarai/hello-sinatra',
+    memory: 128,
+    cpu: 256,
+    env: {
+      PORT: '3000',
+      MESSAGE: std.format('%s-san', provide('username')),
+    },
+    port_mappings: [
+      {
+        container_port: 3000,
+        host_port: 0,
+        protocol: 'tcp',
+      },
+    ],
+  },
+}

--- a/hako.gemspec
+++ b/hako.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'aws-sdk-elasticloadbalancing'
   spec.add_dependency 'aws-sdk-elasticloadbalancingv2'
   spec.add_dependency 'aws-sdk-s3'
+  spec.add_dependency 'aws-sdk-servicediscovery'
   spec.add_dependency 'aws-sdk-sns'
   spec.add_dependency 'aws-sdk-ssm'
   spec.add_dependency 'jsonnet'

--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -14,6 +14,7 @@ require 'hako/schedulers/ecs_definition_comparator'
 require 'hako/schedulers/ecs_elb'
 require 'hako/schedulers/ecs_elb_v2'
 require 'hako/schedulers/ecs_service_comparator'
+require 'hako/schedulers/ecs_service_discovery'
 require 'hako/schedulers/ecs_volume_comparator'
 
 module Hako
@@ -86,6 +87,9 @@ module Hako
             }
           end
         end
+        if options['service_discovery']
+          @service_discovery = EcsServiceDiscovery.new(options.fetch('service_discovery'), @region, dry_run: @dry_run)
+        end
 
         @started_at = nil
         @container_instance_arn = nil
@@ -113,6 +117,9 @@ module Hako
             @autoscaling.apply(Aws::ECS::Types::Service.new(cluster_arn: @cluster, service_name: @app_id))
           end
           ecs_elb_client.modify_attributes
+          if @service_discovery
+            @service_discovery.apply
+          end
         else
           current_service = describe_service
           task_definition_changed, task_definition = register_task_definition(definitions)
@@ -129,12 +136,18 @@ module Hako
               @autoscaling.apply(current_service)
             end
             ecs_elb_client.modify_attributes
+            if @service_discovery
+              @service_discovery.apply
+            end
           else
             Hako.logger.info "Updated service: #{service.service_arn}"
             if @autoscaling
               @autoscaling.apply(service)
             end
             ecs_elb_client.modify_attributes
+            if @service_discovery
+              @service_discovery.apply
+            end
             unless wait_for_ready(service)
               if task_definition_changed
                 Hako.logger.error("Rolling back to #{current_service.task_definition}")
@@ -287,6 +300,13 @@ module Hako
         else
           puts 'Autoscaling: No'
         end
+
+        if service.service_registries.empty?
+          puts 'Service Discovery: No'
+        else
+          puts 'Service Discovery:'
+          @service_discovery.status(service.service_registries)
+        end
       end
 
       # @return [nil]
@@ -304,6 +324,9 @@ module Hako
             end
             ecs_client.delete_service(cluster: service.cluster_arn, service: service.service_arn)
             Hako.logger.info "#{service.service_arn} is deleted"
+          end
+          unless service.service_registries.empty?
+            @service_discovery.remove(service.service_registries)
           end
         else
           puts "Service #{@app_id} doesn't exist"
@@ -823,6 +846,7 @@ module Hako
           params[:desired_count] = current_service.desired_count
         end
         warn_placement_policy_change(current_service)
+        warn_service_registries_change(current_service)
         if service_changed?(current_service, params)
           ecs_client.update_service(params).service
         else
@@ -854,6 +878,10 @@ module Hako
         if ecs_elb_client.find_or_create_load_balancer(front_port)
           ecs_elb_client.modify_attributes
           params[:load_balancers] = [ecs_elb_client.load_balancer_params_for_service]
+        end
+        if @service_discovery
+          @service_discovery.apply
+          params[:service_registries] = @service_discovery.service_registries
         end
         ecs_client.create_service(params).service
       end
@@ -1272,6 +1300,16 @@ module Hako
         end
         if @placement_strategy != placement_strategy
           Hako.logger.warn "Ignoring updated placement_strategy in the configuration, because AWS doesn't allow updating them for now."
+        end
+      end
+
+      # @param [Aws::ECS::Types::Service] service
+      # @return [void]
+      def warn_service_registries_change(service)
+        actual_service_registries = service.service_registries.sort_by(&:registry_arn).map(&:to_h)
+        expected_service_registries = @service_discovery&.service_registries&.sort_by { |s| s[:registry_arn] } || []
+        if actual_service_registries != expected_service_registries
+          Hako.logger.warn "Ignoring updated service_registries in the configuration, because AWS doesn't allow updating them for now."
         end
       end
 

--- a/lib/hako/schedulers/ecs_service_discovery.rb
+++ b/lib/hako/schedulers/ecs_service_discovery.rb
@@ -1,0 +1,258 @@
+# frozen_string_literal: true
+
+require 'aws-sdk-servicediscovery'
+require 'hako'
+require 'hako/schedulers/ecs_service_discovery_service_comparator'
+
+module Hako
+  module Schedulers
+    class EcsServiceDiscovery
+      # @param [Array<Hash>] config
+      # @param [Boolean] dry_run
+      # @param [String] region
+      def initialize(config, region, dry_run:)
+        @region = region
+        @config = config
+        @dry_run = dry_run
+      end
+
+      # @return [void]
+      def apply
+        @config.map do |service_discovery|
+          service = service_discovery.fetch('service')
+          namespace_id = service.fetch('namespace_id')
+          service_name = service.fetch('name')
+          current_service = find_service(namespace_id, service_name)
+          if !current_service
+            if @dry_run
+              Hako.logger.info("Created service discovery service #{service_name} (dry-run)")
+            else
+              current_service = create_service(service)
+              Hako.logger.info("Created service discovery service #{service_name} (#{current_service.id})")
+            end
+          else
+            if service_changed?(service, current_service)
+              if @dry_run
+                Hako.logger.info("Updated service discovery service #{service_name} (#{current_service.id}) (dry-run)")
+              else
+                update_service(current_service.id, service)
+                Hako.logger.info("Updated service discovery service #{service_name} (#{current_service.id})")
+              end
+            end
+            warn_unallowed_service_change(service, current_service)
+          end
+        end
+      end
+
+      # @return [void]
+      def status(service_registries)
+        service_registries.each do |service_registry|
+          service_id = service_registry.registry_arn.slice(%r{service/(.+)\z}, 1)
+          service = get_service(service_id)
+          next unless service
+
+          namespace = service_discovery_client.get_namespace(id: service.namespace_id).namespace
+          instances = service_discovery_client.list_instances(service_id: service.id).flat_map(&:instances)
+          puts "  #{service.name}.#{namespace.name} instance_count=#{instances.size}"
+          instances.each do |instance|
+            instance_attributes = instance.attributes.map { |k, v| "#{k}=#{v}" }.join(', ')
+            puts "    #{instance.id} #{instance_attributes}"
+          end
+        end
+      end
+
+      # @return [void]
+      def remove(service_registries)
+        service_registries.each do |service_registry|
+          service_id = service_registry.registry_arn.slice(%r{service/(.+)\z}, 1)
+          service = get_service(service_id)
+          unless service
+            Hako.logger.info("Service discovery service #{service_name} (#{service_id}) doesn't exist")
+            next
+          end
+          if @dry_run
+            Hako.logger.info("Deleted service discovery service #{service.name} (#{service.id}) (dry-run)")
+          else
+            deleted = false
+            10.times do |i|
+              sleep 10 unless i.zero?
+              begin
+                service_discovery_client.delete_service(id: service.id)
+                deleted = true
+                break
+              rescue Aws::ServiceDiscovery::Errors::ResourceInUse => e
+                Hako.logger.warn("#{e.class}: #{e.message}")
+              end
+            end
+            unless deleted
+              raise Error.new("Unable to delete service discovery service #{service.name} (#{service.id})")
+            end
+
+            Hako.logger.info("Deleted service discovery service #{service.name} (#{service.id})")
+          end
+        end
+      end
+
+      # @return [Hash]
+      def service_registries
+        @config.map do |service_discovery|
+          service = service_discovery.fetch('service')
+          namespace_id = service.fetch('namespace_id')
+          service_name = service.fetch('name')
+          current_service = find_service(namespace_id, service_name)
+          unless current_service
+            raise "Service discovery service #{service_name} not found"
+          end
+
+          {
+            container_name: service_discovery['container_name'],
+            container_port: service_discovery['container_port'],
+            port: service_discovery['port'],
+            registry_arn: current_service.arn,
+          }.reject { |_, v| v.nil? }
+        end
+      end
+
+      private
+
+      # @param [String] namespace_id
+      # @param [String] service_name
+      # @return [Aws::ServiceDiscovery::Types::ServiceSummary, nil]
+      def find_service(namespace_id, service_name)
+        params = {
+          filters: [
+            name: 'NAMESPACE_ID',
+            values: [namespace_id],
+            condition: 'EQ',
+          ],
+        }
+        services = service_discovery_client.list_services(params).flat_map(&:services)
+        services.find { |service| service.name == service_name }
+      end
+
+      # @return [Aws::ServiceDiscovery::Client]
+      def service_discovery_client
+        @service_discovery_client ||= Aws::ServiceDiscovery::Client.new(region: @region)
+      end
+
+      # @param [Hash] service
+      # @return [Aws::ServiceDiscovery::Types::Service]
+      def create_service(service)
+        service_discovery_client.create_service(create_service_params(service)).service
+      end
+
+      # @param [Hash] service
+      # @return [Hash]
+      def create_service_params(service)
+        dns_config = service.fetch('dns_config')
+        params = {
+          name: service.fetch('name'),
+          namespace_id: service['namespace_id'],
+          description: service['description'],
+          dns_config: {
+            namespace_id: dns_config['namespace_id'],
+            routing_policy: dns_config.fetch('routing_policy', 'MULTIVALUE'),
+          },
+        }
+        params[:dns_config][:dns_records] = dns_config.fetch('dns_records').map do |dns_record|
+          {
+            type: dns_record.fetch('type'),
+            ttl: dns_record.fetch('ttl'),
+          }
+        end
+        if (health_check_config = service['health_check_config'])
+          params[:health_check_config] = {
+            type: health_check_config['type'],
+            resource_path: health_check_config['resource_path'],
+            failure_threshold: health_check_config['failure_threshold'],
+          }
+        end
+        if (health_check_custom_config = service['health_check_custom_config'])
+          params[:health_check_custom_config] = {
+            failure_threshold: health_check_custom_config['failure_threshold'],
+          }
+        end
+        params
+      end
+
+      # @param [Hash] expected_service
+      # @param [Aws::ServiceDiscovery::Types::ServiceSummary] actual_service
+      # @return [Boolean]
+      def service_changed?(expected_service, actual_service)
+        EcsServiceDiscoveryServiceComparator.new(update_service_params(expected_service)).different?(actual_service)
+      end
+
+      # @param [String] service_id
+      # @param [Hash] service
+      def update_service(service_id, service)
+        operation_id = service_discovery_client.update_service(
+          id: service_id,
+          service: update_service_params(service),
+        ).operation_id
+        operation = wait_for_operation(operation_id)
+        if operation.status != 'SUCCESS'
+          raise "Unable to update service discovery service (#{operation.error_code}): #{operation.error_message}"
+        end
+      end
+
+      # @param [Hash] service
+      # @return [Hash]
+      def update_service_params(service)
+        dns_config = service.fetch('dns_config')
+        params = {
+          description: service['description'],
+          dns_config: {},
+        }
+        params[:dns_config][:dns_records] = dns_config.fetch('dns_records').map do |dns_record|
+          {
+            type: dns_record.fetch('type'),
+            ttl: dns_record.fetch('ttl'),
+          }
+        end
+        if (health_check_config = service['health_check_config'])
+          params[:health_check_config] = {
+            type: health_check_config['type'],
+            resource_path: health_check_config['resource_path'],
+            failure_threshold: health_check_config['failure_threshold'],
+          }
+        end
+        params
+      end
+
+      # @param [String] service_id
+      # @return [Aws::ServiceDiscovery::Types::GetOperationResponse]
+      def wait_for_operation(operation_id)
+        loop do
+          operation = service_discovery_client.get_operation(operation_id: operation_id).operation
+          return operation if %w[SUCCESS FAIL].include?(operation.status)
+
+          sleep 10
+        end
+      end
+
+      # @param [String] service_id
+      # @return [Aws::ServiceDiscovery::Types::Service, nil]
+      def get_service(service_id)
+        service_discovery_client.get_service(id: service_id).service
+      rescue Aws::ServiceDiscovery::Errors::ServiceNotFound
+        nil
+      end
+
+      # @param [Hash] expected_service
+      # @param [Aws::ServiceDiscovery::Types::ServiceSummary] actual_service
+      # @return [void]
+      def warn_unallowed_service_change(expected_service, actual_service)
+        expected_service = create_service_params(expected_service)
+        if expected_service.dig(:dns_config, :routing_policy) != actual_service.dns_config.routing_policy
+          Hako.logger.warn("Ignoring updated service_discovery.dns_config.routing_policy in the configuration, because AWS doesn't allow updating it for now.")
+        end
+        if expected_service.dig(:health_check_config, :type) != actual_service.health_check_config&.type
+          Hako.logger.warn("Ignoring updated service_discovery.health_check_config.type in the configuration, because AWS doesn't allow updating it for now.")
+        end
+        if expected_service[:health_check_custom_config] != actual_service.health_check_custom_config&.to_h
+          Hako.logger.warn("Ignoring updated service_discovery.health_check_custom_config in the configuration, because AWS doesn't allow updating it for now.")
+        end
+      end
+    end
+  end
+end

--- a/lib/hako/schedulers/ecs_service_discovery.rb
+++ b/lib/hako/schedulers/ecs_service_discovery.rb
@@ -2,6 +2,7 @@
 
 require 'aws-sdk-servicediscovery'
 require 'hako'
+require 'hako/error'
 require 'hako/schedulers/ecs_service_discovery_service_comparator'
 
 module Hako
@@ -23,9 +24,9 @@ module Hako
           namespace_id = service.fetch('namespace_id')
           namespace = get_namespace(namespace_id)
           if !namespace
-            raise "Service discovery namespace #{namespace_id} not found"
+            raise Error.new("Service discovery namespace #{namespace_id} not found")
           elsif namespace.type != 'DNS_PRIVATE'
-            raise "ECS only supports registering a service into a private DNS namespace: #{namespace.name} (#{namespace_id})"
+            raise Error.new("ECS only supports registering a service into a private DNS namespace: #{namespace.name} (#{namespace_id})")
           end
 
           service_name = service.fetch('name')
@@ -108,7 +109,7 @@ module Hako
           service_name = service.fetch('name')
           current_service = find_service(namespace_id, service_name)
           unless current_service
-            raise "Service discovery service #{service_name} not found"
+            raise Error.new("Service discovery service #{service_name} not found")
           end
 
           {
@@ -191,7 +192,7 @@ module Hako
         ).operation_id
         operation = wait_for_operation(operation_id)
         if operation.status != 'SUCCESS'
-          raise "Unable to update service discovery service (#{operation.error_code}): #{operation.error_message}"
+          raise Error.new("Unable to update service discovery service (#{operation.error_code}): #{operation.error_message}")
         end
       end
 

--- a/lib/hako/schedulers/ecs_service_discovery.rb
+++ b/lib/hako/schedulers/ecs_service_discovery.rb
@@ -47,7 +47,7 @@ module Hako
                 Hako.logger.info("Updated service discovery service #{service_name} (#{current_service.id})")
               end
             end
-            warn_unallowed_service_change(service, current_service)
+            warn_disallowed_service_change(service, current_service)
           end
         end
       end
@@ -243,7 +243,7 @@ module Hako
       # @param [Hash] expected_service
       # @param [Aws::ServiceDiscovery::Types::ServiceSummary] actual_service
       # @return [void]
-      def warn_unallowed_service_change(expected_service, actual_service)
+      def warn_disallowed_service_change(expected_service, actual_service)
         expected_service = create_service_params(expected_service)
         if expected_service.dig(:dns_config, :routing_policy) != actual_service.dns_config.routing_policy
           Hako.logger.warn("Ignoring updated service_discovery.dns_config.routing_policy in the configuration, because AWS doesn't allow updating it for now.")

--- a/lib/hako/schedulers/ecs_service_discovery_service_comparator.rb
+++ b/lib/hako/schedulers/ecs_service_discovery_service_comparator.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'hako/schema'
+
+module Hako
+  module Schedulers
+    class EcsServiceDiscoveryServiceComparator
+      # @param [Hash] expected_service
+      def initialize(expected_service)
+        @expected_service = expected_service
+        @schema = service_schema
+      end
+
+      # @param [Aws::ServiceDiscovery::Types::ServiceSummary] actual_service
+      # @return [Boolean]
+      def different?(actual_service)
+        !@schema.same?(actual_service.to_h, @expected_service)
+      end
+
+      private
+
+      def service_schema
+        Schema::Structure.new.tap do |struct|
+          struct.member(:description, Schema::Nullable.new(Schema::String.new))
+          struct.member(:dns_config, dns_config_schema)
+          struct.member(:health_check_config, Schema::Nullable.new(health_check_config_schema))
+        end
+      end
+
+      def dns_config_schema
+        Schema::Structure.new.tap do |struct|
+          struct.member(:dns_records, Schema::UnorderedArray.new(dns_records_schema))
+        end
+      end
+
+      def dns_records_schema
+        Schema::Structure.new.tap do |struct|
+          struct.member(:ttl, Schema::Integer.new)
+          struct.member(:type, Schema::String.new)
+        end
+      end
+
+      def health_check_config_schema
+        Schema::Structure.new.tap do |struct|
+          struct.member(:failure_threshold, Schema::Nullable.new(Schema::Integer.new))
+          struct.member(:resource_path, Schema::Nullable.new(Schema::String.new))
+        end
+      end
+    end
+  end
+end

--- a/lib/hako/schedulers/ecs_service_discovery_service_comparator.rb
+++ b/lib/hako/schedulers/ecs_service_discovery_service_comparator.rb
@@ -23,7 +23,6 @@ module Hako
         Schema::Structure.new.tap do |struct|
           struct.member(:description, Schema::Nullable.new(Schema::String.new))
           struct.member(:dns_config, dns_config_schema)
-          struct.member(:health_check_config, Schema::Nullable.new(health_check_config_schema))
         end
       end
 
@@ -37,13 +36,6 @@ module Hako
         Schema::Structure.new.tap do |struct|
           struct.member(:ttl, Schema::Integer.new)
           struct.member(:type, Schema::String.new)
-        end
-      end
-
-      def health_check_config_schema
-        Schema::Structure.new.tap do |struct|
-          struct.member(:failure_threshold, Schema::Nullable.new(Schema::Integer.new))
-          struct.member(:resource_path, Schema::Nullable.new(Schema::String.new))
         end
       end
     end

--- a/spec/fixtures/jsonnet/ecs-service-discovery.jsonnet
+++ b/spec/fixtures/jsonnet/ecs-service-discovery.jsonnet
@@ -1,0 +1,35 @@
+{
+  scheduler: {
+    type: 'ecs',
+    region: 'ap-northeast-1',
+    cluster: 'eagletmt',
+    desired_count: 1,
+    role: 'ECSServiceRole',
+    service_discovery: [
+      {
+        container_name: 'app',
+        container_port: 80,
+        service: {
+          name: 'ecs-service-discovery',
+          namespace_id: 'ns-1111111111111111',
+          dns_config: {
+            dns_records: [
+              {
+                type: 'SRV',
+                ttl: 60,
+              },
+            ],
+          },
+          health_check_custom_config: {
+            failure_threshold: 1,
+          },
+        },
+      },
+    ],
+  },
+  app: {
+    image: 'busybox',
+    cpu: 32,
+    memory: 64,
+  },
+}

--- a/spec/hako/schedulers/ecs_service_discovery_service_comparator_spec.rb
+++ b/spec/hako/schedulers/ecs_service_discovery_service_comparator_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'hako/schedulers/ecs_service_discovery_service_comparator'
+require 'aws-sdk-servicediscovery'
+
+RSpec.describe Hako::Schedulers::EcsServiceDiscoveryServiceComparator do
+  let(:comparator) { described_class.new(expected_service) }
+  let(:expected_service) do
+    {
+      description: 'foo',
+      dns_config: {
+        dns_records: [
+          ttl: 60,
+          type: 'A',
+        ],
+      },
+      health_check_config: {
+        failure_threshold: 1,
+        resource_path: '/bar',
+        type: 'HTTP',
+      },
+    }
+  end
+  let(:actual_service) do
+    Aws::ServiceDiscovery::Types::ServiceSummary.new(
+      description: 'foo',
+      dns_config: Aws::ServiceDiscovery::Types::DnsConfig.new(
+        dns_records: [
+          Aws::ServiceDiscovery::Types::DnsRecord.new(
+            ttl: 60,
+            type: 'A',
+          ),
+        ],
+      ),
+      health_check_config: Aws::ServiceDiscovery::Types::HealthCheckConfig.new(
+        failure_threshold: 1,
+        resource_path: '/bar',
+        type: 'HTTP',
+      ),
+    )
+  end
+
+  describe '#different?' do
+    context 'when same' do
+      it 'returns false' do
+        expect(comparator).to_not be_different(actual_service)
+      end
+    end
+
+    context 'when some parameters differ' do
+      before do
+        actual_service.dns_config.dns_records[0].ttl = 30
+      end
+
+      it 'returns true' do
+        expect(comparator).to be_different(actual_service)
+      end
+    end
+  end
+end

--- a/spec/hako/schedulers/ecs_service_discovery_service_comparator_spec.rb
+++ b/spec/hako/schedulers/ecs_service_discovery_service_comparator_spec.rb
@@ -15,11 +15,6 @@ RSpec.describe Hako::Schedulers::EcsServiceDiscoveryServiceComparator do
           type: 'A',
         ],
       },
-      health_check_config: {
-        failure_threshold: 1,
-        resource_path: '/bar',
-        type: 'HTTP',
-      },
     }
   end
   let(:actual_service) do
@@ -32,11 +27,6 @@ RSpec.describe Hako::Schedulers::EcsServiceDiscoveryServiceComparator do
             type: 'A',
           ),
         ],
-      ),
-      health_check_config: Aws::ServiceDiscovery::Types::HealthCheckConfig.new(
-        failure_threshold: 1,
-        resource_path: '/bar',
-        type: 'HTTP',
       ),
     )
   end

--- a/spec/hako/schedulers/ecs_spec.rb
+++ b/spec/hako/schedulers/ecs_spec.rb
@@ -367,5 +367,110 @@ RSpec.describe Hako::Schedulers::Ecs do
         expect(logger_io.string).to include('Deployment completed')
       end
     end
+
+    context 'with service discovery' do
+      let(:app) { Hako::Application.new(fixture_root.join('jsonnet', 'ecs-service-discovery.jsonnet')) }
+      let(:task_definition_arn) { "arn:aws:ecs:ap-northeast-1:012345678901:task-definition/#{app.id}:1" }
+      let(:service_discovery_client) { double('Aws::ServiceDiscovery::Client') }
+      let(:namespace_id) { 'ns-1111111111111111' }
+      let(:service_discovery_services) { [] }
+      let(:service_discovery_service_arn) { "arn:aws:servicediscovery:ap-northeast-1:012345678901:service/#{service_discovery_service_id}" }
+      let(:service_discovery_service_id) { 'srv-1111111111111111' }
+
+      before do
+        allow(ecs_client).to receive(:describe_services).with(cluster: 'eagletmt', services: [app.id]).and_return(Aws::ECS::Types::DescribeServicesResponse.new(failures: [], services: [])).once
+        allow(ecs_client).to receive(:describe_task_definition).with(task_definition: app.id).and_raise(Aws::ECS::Errors::ClientException.new(nil, 'Unable to describe task definition')).once
+
+        allow(Aws::ServiceDiscovery::Client).to receive(:new).and_return(service_discovery_client)
+        namespace = Aws::ServiceDiscovery::Types::Namespace.new(type: 'DNS_PRIVATE')
+        allow(service_discovery_client).to receive(:get_namespace).with(id: namespace_id).and_return(Aws::ServiceDiscovery::Types::GetNamespaceResponse.new(namespace: namespace)).twice
+        allow(service_discovery_client).to receive(:list_services).with(
+          filters: [
+            name: 'NAMESPACE_ID',
+            values: [namespace_id],
+            condition: 'EQ',
+          ],
+        ) do
+          services = Aws::ServiceDiscovery::Types::ListServicesResponse.new(services: service_discovery_services).extend(Aws::PageableResponse)
+          services.pager = double('Aws::Pager', truncated?: false)
+          services
+        end.exactly(4).times
+      end
+
+      it 'creates a new service discovery and service' do
+        expect(ecs_client).to receive(:register_task_definition).with(register_task_definition_params).and_return(Aws::ECS::Types::RegisterTaskDefinitionResponse.new(
+          task_definition: Aws::ECS::Types::TaskDefinition.new(
+            task_definition_arn: task_definition_arn,
+          ),
+        )).once
+        expect(service_discovery_client).to receive(:create_service).with(
+          name: 'ecs-service-discovery',
+          namespace_id: namespace_id,
+          description: nil,
+          dns_config: {
+            dns_records: [{
+              type: 'SRV',
+              ttl: 60,
+            }],
+            namespace_id: nil,
+            routing_policy: 'MULTIVALUE',
+          },
+          health_check_custom_config: { failure_threshold: 1 },
+        ) do
+          service = Aws::ServiceDiscovery::Types::Service.new(
+            arn: service_discovery_service_arn,
+            id: service_discovery_service_id,
+            dns_config: Aws::ServiceDiscovery::Types::DnsConfig.new(
+              dns_records: [Aws::ServiceDiscovery::Types::DnsRecord.new(
+                type: 'SRV',
+                ttl: 60,
+              )],
+              routing_policy: 'MULTIVALUE',
+            ),
+            health_check_custom_config: Aws::ServiceDiscovery::Types::HealthCheckCustomConfig.new(
+              failure_threshold: 1
+            ),
+            name: 'ecs-service-discovery',
+            namespace_id: namespace_id,
+          )
+          service_discovery_services << service
+          Aws::ECS::Types::CreateServiceResponse.new(service: service)
+        end.once
+        expect(ecs_client).to receive(:create_service).with(create_service_params.merge(
+          task_definition: task_definition_arn,
+          service_registries: [{
+            container_name: 'app',
+            container_port: 80,
+            registry_arn: service_discovery_service_arn,
+          }],
+        )).and_return(Aws::ECS::Types::CreateServiceResponse.new(
+          service: Aws::ECS::Types::Service.new(
+            placement_constraints: [],
+            placement_strategy: [],
+            service_registries: [Aws::ECS::Types::ServiceRegistry.new(
+              container_name: 'app',
+              container_port: 80,
+              registry_arn: service_discovery_service_arn,
+            )],
+          ),
+        )).once
+        expect(ecs_client).to receive(:update_service).with(update_service_params.merge(
+          task_definition: task_definition_arn,
+        )).and_return(Aws::ECS::Types::UpdateServiceResponse.new(
+          service: Aws::ECS::Types::Service.new(
+            cluster_arn: cluster_arn,
+            service_arn: service_arn,
+            events: [],
+          ),
+        )).once
+        expect(ecs_client).to receive(:describe_services).with(cluster: cluster_arn, services: [service_arn]).and_return(Aws::ECS::Types::DescribeServicesResponse.new(failures: [], services: [dummy_service_response])).once
+
+        scheduler.deploy(containers)
+        expect(logger_io.string).to include('Registered task definition')
+        expect(logger_io.string).to include('Created service discovery service')
+        expect(logger_io.string).to include('Updated service')
+        expect(logger_io.string).to include('Deployment completed')
+      end
+    end
   end
 end

--- a/spec/hako/schedulers/ecs_spec.rb
+++ b/spec/hako/schedulers/ecs_spec.rb
@@ -102,6 +102,7 @@ RSpec.describe Hako::Schedulers::Ecs do
       placement_constraints: [],
       placement_strategy: [],
       deployments: [Aws::ECS::Types::Deployment.new(status: 'PRIMARY', desired_count: 1, running_count: 1)],
+      service_registries: [],
     )
   end
   let(:dummy_container_definition) do
@@ -146,6 +147,7 @@ RSpec.describe Hako::Schedulers::Ecs do
           service: Aws::ECS::Types::Service.new(
             placement_constraints: [],
             placement_strategy: [],
+            service_registries: [],
           ),
         )).once
         expect(ecs_client).to receive(:update_service).with(update_service_params.merge(task_definition: task_definition_arn)).and_return(Aws::ECS::Types::UpdateServiceResponse.new(
@@ -341,6 +343,7 @@ RSpec.describe Hako::Schedulers::Ecs do
           service: Aws::ECS::Types::Service.new(
             placement_constraints: [],
             placement_strategy: [],
+            service_registries: [],
           ),
         )).once
         expect(ecs_client).to receive(:update_service).with(update_service_params.merge(


### PR DESCRIPTION
This adds a new parameter called service_discovery to the ecs scheduler.

Because the type of the serviceRegistries parameter for CreateService
API is Array [1], the service_discovery parameter is defined as an array
even though currently ECS doesn't allow a service to have more than 1
service registries.

[1]: https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_CreateService.html#ECS-CreateService-request-serviceRegistries