### PR TITLE
Support specifying tag for app container in definition

### DIFF
--- a/lib/hako/app_container.rb
+++ b/lib/hako/app_container.rb
@@ -6,7 +6,7 @@ module Hako
   class AppContainer < Container
     # @return [String]
     def image_tag
-      "#{@definition['image']}:#{@definition['tag']}"
+      "#{@definition['image']}:#{@definition.fetch('tag', 'latest')}"
     end
   end
 end

--- a/lib/hako/cli.rb
+++ b/lib/hako/cli.rb
@@ -80,7 +80,6 @@ module Hako
 
       def parse!(argv)
         @force = false
-        @tag = 'latest'
         @dry_run = false
         @verbose = false
         @timeout = DEFAULT_TIMEOUT
@@ -98,7 +97,7 @@ module Hako
           opts.banner = 'hako deploy [OPTIONS] FILE'
           opts.version = VERSION
           opts.on('-f', '--force', 'Run deployment even if nothing is changed') { @force = true }
-          opts.on('-t', '--tag=TAG', 'Specify tag (default: latest)') { |v| @tag = v }
+          opts.on('-t', '--tag=TAG', 'Specify tag') { |v| @tag = v }
           opts.on('-n', '--dry-run', 'Enable dry-run mode') { @dry_run = true }
           opts.on('-v', '--verbose', 'Enable verbose logging') { @verbose = true }
           opts.on('--timeout=TIMEOUT_SEC', "Timeout deployment after TIMEOUT_SEC seconds (default: #{DEFAULT_TIMEOUT})") { |v| @timeout = v.to_i }
@@ -167,7 +166,6 @@ module Hako
       end
 
       def parse!(argv)
-        @tag = 'latest'
         @dry_run = false
         @containers = []
         @env = {}
@@ -187,7 +185,7 @@ module Hako
         @parser ||= OptionParser.new do |opts|
           opts.banner = 'hako oneshot [OPTIONS] FILE COMMAND ARG...'
           opts.version = VERSION
-          opts.on('-t', '--tag=TAG', 'Specify tag (default: latest)') { |v| @tag = v }
+          opts.on('-t', '--tag=TAG', 'Specify tag') { |v| @tag = v }
           opts.on('-n', '--dry-run', 'Enable dry-run mode') { @dry_run = true }
           opts.on('-c', '--container=NAME', 'Additional container name to start with the app container') { |v| @containers << v }
           opts.on('-v', '--verbose', 'Enable verbose logging') { @verbose = true }

--- a/lib/hako/commander.rb
+++ b/lib/hako/commander.rb
@@ -15,10 +15,10 @@ module Hako
     end
 
     # @param [Boolean] force
-    # @param [String] tag
+    # @param [String, nil] tag
     # @param [Boolean] dry_run
     # @return [nil]
-    def deploy(force: false, tag: 'latest', dry_run: false, timeout:)
+    def deploy(force: false, tag:, dry_run: false, timeout:)
       containers = load_containers(tag, dry_run: dry_run)
       scripts = @app.definition.fetch('scripts', []).map { |config| load_script(config, dry_run: dry_run) }
       volumes = @app.definition.fetch('volumes', {})
@@ -42,7 +42,7 @@ module Hako
     end
 
     # @param [Array<String>] commands
-    # @param [String] tag
+    # @param [String, nil] tag
     # @param [Hash<String, String>] env
     # @param [Boolean] dry_run
     # @param [Boolean] no_wait
@@ -110,12 +110,12 @@ module Hako
       exit_code
     end
 
-    # @param [String] tag
+    # @param [String, nil] tag
     # @param [Boolean] dry_run
     # @param [Array<String>, nil] with
     # @return [Hash<String, Container>]
     def load_containers(tag, dry_run:, with: nil)
-      DefinitionLoader.new(@app, dry_run: dry_run).load(tag, with: with)
+      DefinitionLoader.new(@app, dry_run: dry_run).load(tag: tag, with: with)
     end
 
     # @param [Hash] scheduler_definition

--- a/lib/hako/definition_loader.rb
+++ b/lib/hako/definition_loader.rb
@@ -14,10 +14,10 @@ module Hako
       @dry_run = dry_run
     end
 
-    # @param [String] tag
+    # @param [String, nil] tag
     # @param [Array<String>, nil] with
     # @return [Hash<String, Container>]
-    def load(tag, with: nil)
+    def load(tag: nil, with: nil)
       # XXX: Load additional_containers for compatibility
       sidecars = @app.definition.fetch('sidecars', @app.definition.fetch('additional_containers', {}))
       container_names = ['app']
@@ -32,7 +32,7 @@ module Hako
 
     private
 
-    # @param [String] tag
+    # @param [String, nil] tag
     # @param [Array<String>] container_names
     # @param [Hash<String, Hash>] sidecars
     # @return [Hash<String, Container>]
@@ -44,7 +44,8 @@ module Hako
           containers[name] =
             case name
             when 'app'
-              AppContainer.new(@app, @app.definition['app'].merge('tag' => tag), dry_run: @dry_run)
+              @app.definition['app']['tag'] = tag if tag
+              AppContainer.new(@app, @app.definition['app'], dry_run: @dry_run)
             else
               Container.new(@app, sidecars.fetch(name), dry_run: @dry_run)
             end

--- a/spec/hako/definition_loader_spec.rb
+++ b/spec/hako/definition_loader_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe Hako::DefinitionLoader do
 
   describe '#load' do
     it 'loads all containers' do
-      containers = definition_loader.load('latest')
+      containers = definition_loader.load(tag: 'tag')
       expect(containers.keys).to match_array(%w[app front])
       expect(containers.values).to all(be_a(Hako::Container))
-      expect(containers['app'].image_tag).to eq('app-image:latest')
+      expect(containers['app'].image_tag).to eq('app-image:tag')
       expect(containers['app'].links).to eq([])
       expect(containers['front'].image_tag).to eq('front-image')
       expect(containers['front'].links).to eq([])
@@ -23,9 +23,9 @@ RSpec.describe Hako::DefinitionLoader do
 
     context 'with `with`' do
       it 'loads only specified definition' do
-        containers = definition_loader.load('latest', with: [])
+        containers = definition_loader.load(tag: 'tag', with: [])
         expect(containers.keys).to match_array(['app'])
-        expect(containers['app'].image_tag).to eq('app-image:latest')
+        expect(containers['app'].image_tag).to eq('app-image:tag')
         expect(containers['app'].links).to eq([])
       end
     end
@@ -34,14 +34,14 @@ RSpec.describe Hako::DefinitionLoader do
       let(:fixture_name) { 'default_with_links.jsonnet' }
 
       it 'loads all containers' do
-        containers = definition_loader.load('latest')
+        containers = definition_loader.load
         expect(containers.keys).to match_array(%w[app redis memcached fluentd])
         expect(containers.values).to all(be_a(Hako::Container))
       end
 
       context 'with `with`' do
         it 'loads specified definition and linked containers' do
-          containers = definition_loader.load('latest', with: [])
+          containers = definition_loader.load(with: [])
           expect(containers.keys).to match_array(%w[app redis memcached])
         end
       end
@@ -51,14 +51,14 @@ RSpec.describe Hako::DefinitionLoader do
       let(:fixture_name) { 'default_with_volumes_from.jsonnet' }
 
       it 'loads all containers' do
-        containers = definition_loader.load('latest')
+        containers = definition_loader.load
         expect(containers.keys).to match_array(%w[app redis memcached fluentd])
         expect(containers.values).to all(be_a(Hako::Container))
       end
 
       context 'with `with`' do
         it 'loads specified definition and referenced containers' do
-          containers = definition_loader.load('latest', with: [])
+          containers = definition_loader.load(with: [])
           expect(containers.keys).to match_array(%w[app redis memcached])
         end
       end

--- a/spec/hako/schedulers/ecs_spec.rb
+++ b/spec/hako/schedulers/ecs_spec.rb
@@ -8,8 +8,7 @@ require 'hako/schedulers/ecs'
 
 RSpec.describe Hako::Schedulers::Ecs do
   let(:dry_run) { false }
-  let(:tag) { 'latest' }
-  let(:containers) { Hako::DefinitionLoader.new(app, dry_run: dry_run).load(tag) }
+  let(:containers) { Hako::DefinitionLoader.new(app, dry_run: dry_run).load }
   let(:scripts) do
     app.definition.fetch('scripts', []).map do |config|
       Hako::Loader.new(Hako::Scripts, 'hako/scripts').load(config.fetch('type')).new(app, config, dry_run: dry_run)


### PR DESCRIPTION
I would like to specify the default tag for the app container in the definition so that we don't have to specify the `--tag` option every time for the application using a non-`latest` tag as the default tag.