### PR TITLE
Support sharing load balancers

### DIFF
--- a/examples/hello-shared-alb.jsonnet
+++ b/examples/hello-shared-alb.jsonnet
@@ -1,0 +1,50 @@
+{
+  scheduler: {
+    type: 'ecs',
+    region: 'ap-northeast-1',
+    cluster: 'eagletmt',
+    desired_count: 2,
+    role: 'ecsServiceRole',
+    elb_v2: {
+      // Use existing load balancer
+      load_balancer_name: 'hello-shared-alb',
+      // VPC id where the target group is located
+      vpc_id: 'vpc-WWWWWWWW',
+      // Health check path of the target group
+      health_check_path: '/site/sha',
+      target_group_attributes: {
+        // http://docs.aws.amazon.com/en_us/elasticloadbalancing/latest/application/load-balancer-target-groups.html#target-group-attributes
+        'deregistration_delay.timeout_seconds': '20',
+      },
+    },
+  },
+  app: {
+    image: 'ryotarai/hello-sinatra',
+    memory: 128,
+    cpu: 256,
+    env: {
+      PORT: '3000',
+    },
+    secrets: [{
+      name: 'MESSAGE',
+      value_from: 'arn:aws:ssm:ap-northeast-1:012345678901:parameter/hako/hello-shared-alb/secret-message',
+    }],
+  },
+  sidecars: {
+    front: {
+      image_tag: 'hako-nginx',
+      memory: 32,
+      cpu: 32,
+    },
+  },
+  scripts: [
+    (import 'front.libsonnet') + {
+      backend_port: 3000,
+      locations: {
+        '/': {
+          allow_only_from: ['10.0.0.0/24'],
+        },
+      },
+    },
+  ],
+}

--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -103,6 +103,7 @@ module Hako
           validation_error!('desired_count must be set')
         end
         front_port = determine_front_port
+        ecs_elb_client.find_or_create_load_balancer(front_port)
         @scripts.each { |script| script.deploy_started(containers, front_port) }
         definitions = create_definitions(containers)
 
@@ -886,7 +887,6 @@ module Hako
           params[:desired_count] = 0
         end
         if ecs_elb_client.find_or_create_load_balancer(front_port)
-          ecs_elb_client.modify_attributes
           params[:load_balancers] = [ecs_elb_client.load_balancer_params_for_service]
         end
         if @service_discovery


### PR DESCRIPTION
When `elb_v2` field has `load_balancer_name` but doesn't have
`target_group_name`, hako will manage only the target group and doesn't
touch the load balancer.
This is useful when one load balancer is shared with multiple target
groups and some of them is deployed by hako.