### PR TITLE
Support systemControls option of task definition

### DIFF
--- a/lib/hako/container.rb
+++ b/lib/hako/container.rb
@@ -33,6 +33,7 @@ module Hako
       privileged
       readonly_root_filesystem
       docker_security_options
+      system_controls
     ].each do |name|
       define_method(name) do
         @definition[name]
@@ -186,6 +187,18 @@ module Hako
         end
 
         ret
+      end
+    end
+
+    # @return [Array<Hash>, nil]
+    def system_controls
+      if @definition.key?('system_controls')
+        @definition['system_controls'].map do |system_control|
+          {
+            namespace: system_control.fetch('namespace'),
+            value: system_control.fetch('value'),
+          }
+        end
       end
     end
 

--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -651,6 +651,7 @@ module Hako
           extra_hosts: container.extra_hosts,
           readonly_root_filesystem: container.readonly_root_filesystem,
           docker_security_options: container.docker_security_options,
+          system_controls: container.system_controls,
         }
       end
 
@@ -1240,6 +1241,11 @@ module Hako
         end
         if definition[:entry_point]
           cmd << '--entrypoint' << definition[:entry_point]
+        end
+        if definition[:system_controls]
+          definition.fetch(:system_controls).each do |system_control|
+            cmd << '--sysctl' << "#{system_control.fetch(:namespace)}=#{system_control.fetch(:value)}"
+          end
         end
 
         cmd << "\\\n  "

--- a/lib/hako/schedulers/ecs_definition_comparator.rb
+++ b/lib/hako/schedulers/ecs_definition_comparator.rb
@@ -45,6 +45,7 @@ module Hako
           struct.member(:linux_parameters, Schema::Nullable.new(linux_parameters_schema))
           struct.member(:readonly_root_filesystem, Schema::Nullable.new(Schema::Boolean.new))
           struct.member(:docker_security_options, Schema::Nullable.new(Schema::UnorderedArray.new(Schema::String.new)))
+          struct.member(:system_controls, Schema::Nullable.new(system_controls_schema))
         end
       end
 
@@ -168,6 +169,13 @@ module Hako
         Schema::Structure.new.tap do |struct|
           struct.member(:container_name, Schema::String.new)
           struct.member(:condition, Schema::String.new)
+        end
+      end
+
+      def system_controls_schema
+        Schema::Structure.new.tap do |struct|
+          struct.member(:namespace, Schema::String.new)
+          struct.member(:value, Schema::String.new)
         end
       end
     end

--- a/spec/hako/schedulers/ecs_spec.rb
+++ b/spec/hako/schedulers/ecs_spec.rb
@@ -85,6 +85,7 @@ RSpec.describe Hako::Schedulers::Ecs do
         extra_hosts: nil,
         readonly_root_filesystem: nil,
         docker_security_options: nil,
+        system_controls: nil,
       }],
       volumes: [],
       requires_compatibilities: nil,


### PR DESCRIPTION
This feature is useful to configure a parameter like net.core.somaxconn.

- https://docs.aws.amazon.com/AmazonECS/latest/userguide/task_definition_parameters.html
- https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_SystemControl.html

@eagletmt Please review 🙏 