### PR TITLE
Show --health-* options in hako deploy --dry-run

### DIFF
--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -1247,6 +1247,28 @@ module Hako
             cmd << '--sysctl' << "#{system_control.fetch(:namespace)}=#{system_control.fetch(:value)}"
           end
         end
+        if definition[:health_check]
+          if definition[:health_check][:command]
+            health_check_command_type = definition[:health_check][:command][0]
+            case health_check_command_type
+            when 'NONE'
+              cmd << '--no-healthcheck'
+            when 'CMD', 'CMD-SHELL'
+              health_check_command = definition[:health_check][:command][1..-1].join(' ')
+              cmd << '--health-cmd' << health_check_command.inspect
+            else
+              raise "Health check command type #{health_check_command_type} is not supported.\nCMD, CMD-SHELL and NONE are supported."
+            end
+          end
+          if definition[:health_check][:retries]
+            cmd << '--health-retries' << definition[:health_check][:retries]
+          end
+          %i[interval timeout start_period].each do |property|
+            if definition[:health_check][property]
+              cmd << "--health-#{property}" << "#{definition[:health_check][property]}s"
+            end
+          end
+        end
 
         cmd << "\\\n  "
         definition.fetch(:environment).each do |env|

--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -1257,7 +1257,7 @@ module Hako
               health_check_command = definition[:health_check][:command][1..-1].join(' ')
               cmd << '--health-cmd' << health_check_command.inspect
             else
-              raise "Health check command type #{health_check_command_type} is not supported.\nCMD, CMD-SHELL and NONE are supported."
+              raise "Health check command type #{health_check_command_type} is not supported. CMD, CMD-SHELL and NONE are supported."
             end
           end
           if definition[:health_check][:retries]


### PR DESCRIPTION
Docker container health check feature has been supported in https://github.com/eagletmt/hako/pull/56 . However, that change does not include `--health-*` options in `hako deploy --dry-run`. This pull request provides the missing piece.

`CMD` and `CMD-SHELL` are notation which come from [Docker API (ContainerCreate)](https://docs.docker.com/engine/api/v1.35/#operation/ContainerCreate). If `CMD-SHELL` is specified, [given command-line is wrapped with container's default shell](https://github.com/moby/moby/blob/8e610b2b55bfd1bfa9436ab110d311f5e8a74dcb/daemon/health.go#L373-L381). /bin/sh is used if default shell is not specified.

The `docker run` is a high level API for Docker CLI. If `--health-cmd` option is given, the command seems create a container by ContainerCrate API with `CMD-SHELL` health checking configuration  before run the container . Therefore, it is not necessarily accurate when `CMD` is specified. (I guess ecs-agent uses ContainerCreate API directly.) But I think that it is acceptable.

```
(cmd)> docker run --rm --health-cmd "echo 'foo'" --entrypoint '' -it envoyproxy/envoy /bin/bash
(ins)> docker inspect 78a09ad7e0de
  # 
  # snip..
  #
"HealthCheck": {
    "Test": [
        "CMD-SHELL",
        "echo 'foo'"
    ]
},
```

@eagletmt Review please 🙏 

