### PR TITLE
support --ext-var argument

### DIFF
--- a/lib/hako/application.rb
+++ b/lib/hako/application.rb
@@ -15,7 +15,7 @@ module Hako
     #   @return [Hash]
     attr_reader :id, :root_path, :definition
 
-    def initialize(definition_path, expand_variables: true, ask_keys: false)
+    def initialize(definition_path, expand_variables: true, ask_keys: false, ext_vars: {})
       path = Pathname.new(definition_path)
       @id = path.basename.sub_ext('').to_s
       @root_path = path.parent
@@ -24,7 +24,7 @@ module Hako
         when '.yml', '.yaml'
           YamlLoader.new.load(path)
         when '.jsonnet', '.json'
-          JsonnetLoader.new(self, expand_variables: expand_variables, ask_keys: ask_keys).load(path)
+          JsonnetLoader.new(self, expand_variables: expand_variables, ask_keys: ask_keys, ext_vars: ext_vars).load(path)
         else
           raise Error.new("Unknown extension: #{path}")
         end

--- a/lib/hako/cli.rb
+++ b/lib/hako/cli.rb
@@ -73,6 +73,7 @@ module Hako
           else
             {}
           end
+        options.merge!(ext_vars: @ext_vars)
         Commander.new(Application.new(@definition_path, options)).deploy(force: @force, tag: @tag, dry_run: @dry_run, timeout: @timeout)
       end
 
@@ -83,6 +84,7 @@ module Hako
         @dry_run = false
         @verbose = false
         @timeout = DEFAULT_TIMEOUT
+        @ext_vars = {}
         parser.parse!(argv)
         @definition_path = argv.first
 
@@ -101,6 +103,10 @@ module Hako
           opts.on('-n', '--dry-run', 'Enable dry-run mode') { @dry_run = true }
           opts.on('-v', '--verbose', 'Enable verbose logging') { @verbose = true }
           opts.on('--timeout=TIMEOUT_SEC', "Timeout deployment after TIMEOUT_SEC seconds (default: #{DEFAULT_TIMEOUT})") { |v| @timeout = v.to_i }
+          opts.on('--ext-var=KEY=VAL', 'Specify external variable for Jsonnet') do |arg|
+            k, v = arg.split('=', 2)
+            @ext_vars[k] = v
+          end
         end
       end
     end
@@ -121,12 +127,14 @@ module Hako
           else
             {}
           end
+        options.merge!(ext_vars: @ext_vars)
         Commander.new(Application.new(@definition_path, options)).rollback(dry_run: @dry_run)
       end
 
       def parse!(argv)
         @dry_run = false
         @verbose = false
+        @ext_vars = {}
         parser.parse!(argv)
         @definition_path = argv.first
 
@@ -142,6 +150,10 @@ module Hako
           opts.version = VERSION
           opts.on('-n', '--dry-run', 'Enable dry-run mode') { @dry_run = true }
           opts.on('-v', '--verbose', 'Enable verbose logging') { @verbose = true }
+          opts.on('--ext-var=KEY=VAL', 'Specify external variable for Jsonnet') do |arg|
+            k, v = arg.split('=', 2)
+            @ext_vars[k] = v
+          end
         end
       end
     end
@@ -162,6 +174,7 @@ module Hako
           else
             {}
           end
+        options.merge!(ext_vars: @ext_vars)
         Commander.new(Application.new(@definition_path, options)).oneshot(@argv, tag: @tag, containers: @containers, env: @env, dry_run: @dry_run, no_wait: @no_wait)
       end
 
@@ -171,6 +184,7 @@ module Hako
         @env = {}
         @verbose = false
         @no_wait = false
+        @ext_vars = {}
         parser.parse!(argv)
         @definition_path = argv.shift
         @argv = argv
@@ -194,6 +208,10 @@ module Hako
             k, v = arg.split('=', 2)
             @env[k] = v
           end
+          opts.on('--ext-var=KEY=VAL', 'Specify external variable for Jsonnet') do |arg|
+            k, v = arg.split('=', 2)
+            @ext_vars[k] = v
+          end
         end
       end
     end
@@ -202,12 +220,13 @@ module Hako
       def run(argv)
         parse!(argv)
         require 'hako/application'
-        app = Application.new(@path, expand_variables: @expand_variables)
+        app = Application.new(@path, expand_variables: @expand_variables, ext_vars: @ext_vars)
         puts JSON.pretty_generate(app.definition)
       end
 
       def parse!(argv)
         @expand_variables = false
+        @ext_vars = {}
         parser.parse!(argv)
         @path = argv.first
         if @path.nil?
@@ -221,6 +240,10 @@ module Hako
           opts.banner = 'hako show-definition FILE'
           opts.version = VERSION
           opts.on('--expand', 'Expand variables (Jsonnet only)') { @expand_variables = true }
+          opts.on('--ext-var=KEY=VAL', 'Specify external variable for Jsonnet') do |arg|
+            k, v = arg.split('=', 2)
+            @ext_vars[k] = v
+          end
         end
       end
     end
@@ -230,10 +253,11 @@ module Hako
         parse!(argv)
         require 'hako/application'
         require 'hako/commander'
-        Commander.new(Application.new(@definition_path, expand_variables: false)).status
+        Commander.new(Application.new(@definition_path, expand_variables: false, ext_vars: @ext_vars)).status
       end
 
       def parse!(argv)
+        @ext_vars = {}
         parser.parse!(argv)
         @definition_path = argv.first
 
@@ -247,6 +271,10 @@ module Hako
         @parser ||= OptionParser.new do |opts|
           opts.banner = 'hako status FILE'
           opts.version = VERSION
+          opts.on('--ext-var=KEY=VAL', 'Specify external variable for Jsonnet') do |arg|
+            k, v = arg.split('=', 2)
+            @ext_vars[k] = v
+          end
         end
       end
     end
@@ -257,11 +285,12 @@ module Hako
         require 'hako/application'
         require 'hako/commander'
 
-        Commander.new(Application.new(@definition_path, expand_variables: false)).remove(dry_run: @dry_run)
+        Commander.new(Application.new(@definition_path, expand_variables: false, ext_vars: @ext_vars)).remove(dry_run: @dry_run)
       end
 
       def parse!(argv)
         @dry_run = false
+        @ext_vars = {}
         parser.parse!(argv)
         @definition_path = argv.first
 
@@ -276,6 +305,10 @@ module Hako
           opts.banner = 'hako remove FILE'
           opts.version = VERSION
           opts.on('-n', '--dry-run', 'Enable dry-run mode') { @dry_run = true }
+          opts.on('--ext-var=KEY=VAL', 'Specify external variable for Jsonnet') do |arg|
+            k, v = arg.split('=', 2)
+            @ext_vars[k] = v
+          end
         end
       end
     end
@@ -286,11 +319,12 @@ module Hako
         require 'hako/application'
         require 'hako/commander'
 
-        Commander.new(Application.new(@definition_path, expand_variables: false)).stop(dry_run: @dry_run)
+        Commander.new(Application.new(@definition_path, expand_variables: false, ext_vars: @ext_vars)).stop(dry_run: @dry_run)
       end
 
       def parse!(argv)
         @dry_run = false
+        @ext_vars = {}
         parser.parse!(argv)
         @definition_path = argv.first
 
@@ -305,6 +339,10 @@ module Hako
           opts.banner = 'hako stop FILE'
           opts.version = VERSION
           opts.on('-n', '--dry-run', 'Enable dry-run mode') { @dry_run = true }
+          opts.on('--ext-var=KEY=VAL', 'Specify external variable for Jsonnet') do |arg|
+            k, v = arg.split('=', 2)
+            @ext_vars[k] = v
+          end
         end
       end
     end

--- a/lib/hako/jsonnet_loader.rb
+++ b/lib/hako/jsonnet_loader.rb
@@ -12,11 +12,12 @@ module Hako
     # @param [Application] application
     # @param [Boolean] expand_variables
     # @param [Boolean] ask_keys
-    def initialize(application, expand_variables:, ask_keys:)
+    def initialize(application, expand_variables:, ask_keys:, ext_vars:)
       @vm = Jsonnet::VM.new
       @root_path = application.root_path
       define_provider_functions(expand_variables, ask_keys)
       @vm.ext_var('appId', application.id)
+      ext_vars.each { |k, v| @vm.ext_var(k.to_s, v) }
     end
 
     # @param [Pathname] path

--- a/spec/fixtures/jsonnet/default_with_ext_var.jsonnet
+++ b/spec/fixtures/jsonnet/default_with_ext_var.jsonnet
@@ -1,0 +1,11 @@
+{
+  app: {
+    image: std.extVar('app_image'),
+  },
+  sidecars: {
+    front: {
+      type: 'nginx',
+      image_tag: std.extVar('front_image'),
+    },
+  },
+}

--- a/spec/hako/definition_loader_spec.rb
+++ b/spec/hako/definition_loader_spec.rb
@@ -63,5 +63,37 @@ RSpec.describe Hako::DefinitionLoader do
         end
       end
     end
+
+    context 'with ext_vars' do
+      let(:fixture_name) { 'default_with_ext_var.jsonnet' }
+      let(:app) { Hako::Application.new(fixture_root.join('jsonnet', fixture_name), ext_vars: ext_vars) }
+
+      context 'specify ext_vars' do
+        let(:ext_vars) do
+          {
+            app_image: 'app-image',
+            front_image: 'front-image',
+          }
+        end
+
+        it 'loads all containers' do
+          containers = definition_loader.load
+          expect(containers.keys).to match_array(%w[app front])
+          expect(containers.values).to all(be_a(Hako::Container))
+          expect(containers['app'].image_tag).to eq('app-image:latest')
+          expect(containers['app'].links).to eq([])
+          expect(containers['front'].image_tag).to eq('front-image')
+          expect(containers['front'].links).to eq([])
+        end
+      end
+
+      context 'not specify ext_vars' do
+        let(:ext_vars) { {} }
+
+        it 'error occur' do
+          expect { definition_loader.load }.to raise_error(Jsonnet::EvaluationError)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
I will prepare common files for all environments when deploying using hako.
and it reads the variable for each environment defined in another file.
It is currently used after replacing it with `sed -i -e" s / {{ENV}} / dev / g "base.jsonnet`.


base.jsonnet

```jsonnet
local vars = import './{{ ENV }}/variables.libsonnet';

{
  scheduler: {
    cluster: vars.cluster,
  ...
```

dev/variables.libsonnet

```jsonnet
{
  env: 'dev',
  cluster: 'cluster-dev',
  ...
}
```

stg/variables.libsonnet

```jsonnet
{
  env: 'stg',
  cluster: 'cluster-stg',
  ...
}
```

jsonnet has [`sed.extVar`](https://jsonnet.org/ref/stdlib.html) for receiving external variables.
I can specify this from the command line.