### PR TITLE
Stop printing volumes_from definitions in dry-run

### DIFF
--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -1227,9 +1227,6 @@ module Hako
             cmd << '--tmpfs' << "#{tmpfs[:container_path]}:#{options.join(',')}"
           end
         end
-        definition.fetch(:volumes_from).each do |volumes_from|
-          p volumes_from
-        end
         if definition[:user]
           cmd << '--user' << definition[:user]
         end


### PR DESCRIPTION
#55 should show them in the form of command line arguments.