### PR TITLE
Do not try to update assign_public_ip when it is not changed

### DIFF
--- a/lib/hako/schedulers/ecs_service_comparator.rb
+++ b/lib/hako/schedulers/ecs_service_comparator.rb
@@ -46,7 +46,7 @@ module Hako
         Schema::Structure.new.tap do |struct|
           struct.member(:subnets, Schema::UnorderedArray.new(Schema::String.new))
           struct.member(:security_groups, Schema::UnorderedArray.new(Schema::String.new))
-          struct.member(:assign_public_ip, Schema::String.new)
+          struct.member(:assign_public_ip, Schema::WithDefault.new(Schema::String.new, 'DISABLED'))
         end
       end
 


### PR DESCRIPTION
assign_public_ip is set to DISABLED when it is not specified.

https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_AwsVpcConfiguration.html#ECS-Type-AwsVpcConfiguration-assignPublicIp