### PR TITLE
Update .rubocop.yml for RuboCop v0.77

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,12 +4,12 @@ AllCops:
   DisplayCopNames: true
   TargetRubyVersion: 2.3
 
-Layout/IndentFirstArgument:
+Layout/FirstArgumentIndentation:
   Enabled: false
 
 Naming/PredicateName:
   Enabled: false
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:
   Enabled: false
 Naming/MemoizedInstanceVariableName:
   Enabled: false


### PR DESCRIPTION
```
$ bundle exec rubocop -v
0.77.0
$ bundle exec rubocop
Error: The `Layout/IndentFirstArgument` cop has been renamed to `Layout/FirstArgumentIndentation`.
(obsolete configuration found in .rubocop.yml, please update it)
The `Naming/UncommunicativeMethodParamName` cop has been renamed to `Naming/MethodParameterName`.
(obsolete configuration found in .rubocop.yml, please update it)
```

This should fix the CI failure in #90.

Ref: https://github.com/rubocop-hq/rubocop/releases/tag/v0.77.0