### PR TITLE
Support capacity provider strategy

### DIFF
--- a/hako.gemspec
+++ b/hako.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'aws-sdk-cloudwatch'
   spec.add_dependency 'aws-sdk-cloudwatchlogs'
   spec.add_dependency 'aws-sdk-ec2'
-  spec.add_dependency 'aws-sdk-ecs', '>= 1.31.0'
+  spec.add_dependency 'aws-sdk-ecs', '>= 1.54.0'
   spec.add_dependency 'aws-sdk-elasticloadbalancing'
   spec.add_dependency 'aws-sdk-elasticloadbalancingv2'
   spec.add_dependency 'aws-sdk-s3'

--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -883,9 +883,10 @@ module Hako
           # Keep current desired_count if autoscaling is enabled
           params[:desired_count] = current_service.desired_count
         end
-        # Copy the curreent capacity provider strategy in order to avoid a
-        # perpetual diff when the service specifies no strategy and uses the
-        # cluster's default capacity.
+        # Copy the current capacity provider strategy in order to avoid a
+        # perpetual diff when the service is created with no strategy to use the
+        # cluster's default capacity provider strategy, which results in the
+        # strategy being set to the default strategy at that moment.
         # It is not allowed to update the service to use the cluster's default
         # capacity provider strategy when it is using a non-default capacity
         # provider strategy.

--- a/lib/hako/schedulers/ecs_service_comparator.rb
+++ b/lib/hako/schedulers/ecs_service_comparator.rb
@@ -23,6 +23,7 @@ module Hako
           struct.member(:desired_count, Schema::Integer.new)
           struct.member(:task_definition, Schema::String.new)
           struct.member(:deployment_configuration, Schema::WithDefault.new(deployment_configuration_schema, default_configuration))
+          struct.member(:capacity_provider_strategy, Schema::Nullable.new(Schema::UnorderedArray.new(capacity_provider_strategy_schema)))
           struct.member(:platform_version, Schema::WithDefault.new(Schema::String.new, 'LATEST'))
           struct.member(:network_configuration, Schema::Nullable.new(network_configuration_schema))
           struct.member(:health_check_grace_period_seconds, Schema::Nullable.new(Schema::Integer.new))
@@ -33,6 +34,14 @@ module Hako
         Schema::Structure.new.tap do |struct|
           struct.member(:maximum_percent, Schema::Integer.new)
           struct.member(:minimum_healthy_percent, Schema::Integer.new)
+        end
+      end
+
+      def capacity_provider_strategy_schema
+        Schema::Structure.new.tap do |struct|
+          struct.member(:capacity_provider, Schema::String.new)
+          struct.member(:weight, Schema::WithDefault.new(Schema::Integer.new, 0))
+          struct.member(:base, Schema::WithDefault.new(Schema::Integer.new, 0))
         end
       end
 

--- a/spec/hako/schedulers/ecs_spec.rb
+++ b/spec/hako/schedulers/ecs_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe Hako::Schedulers::Ecs do
       placement_strategy: [],
       scheduling_strategy: nil,
       launch_type: nil,
+      capacity_provider_strategy: nil,
       platform_version: nil,
       network_configuration: nil,
       health_check_grace_period_seconds: nil,
@@ -49,6 +50,7 @@ RSpec.describe Hako::Schedulers::Ecs do
       service: app.id,
       desired_count: 1,
       deployment_configuration: nil,
+      capacity_provider_strategy: nil,
       platform_version: nil,
       network_configuration: nil,
       health_check_grace_period_seconds: nil,
@@ -529,6 +531,7 @@ RSpec.describe Hako::Schedulers::Ecs do
           placement_constraints: [],
           started_by: 'hako oneshot',
           launch_type: nil,
+          capacity_provider_strategy: nil,
           platform_version: nil,
           network_configuration: nil,
         ).and_return(Aws::ECS::Types::RunTaskResponse.new(


### PR DESCRIPTION
This adds a new parameter called capacity_provider_strategy, which maps to [service's capacityProviderStrategy](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Service.html#ECS-Type-Service-capacityProviderStrategy), to the ecs scheduler. 

References:
- [Amazon ECS Cluster Capacity Providers](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-capacity-providers.html)
- [CreateService API](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_CreateService.html#ECS-CreateService-request-capacityProviderStrategy)
- [UpdateService API](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_UpdateService.html#ECS-UpdateService-request-capacityProviderStrategy)
- [RunTask API](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html#ECS-RunTask-request-capacityProviderStrategy)