### PR TITLE
Support FireLens configuration

### DIFF
--- a/lib/hako/container.rb
+++ b/lib/hako/container.rb
@@ -213,6 +213,16 @@ module Hako
       end
     end
 
+    def firelens_configuration
+      if @definition.key?('firelens_configuration')
+        conf = @definition['firelens_configuration']
+        {
+          type: conf.fetch('type'),
+          options: conf.fetch('options', nil),
+        }
+      end
+    end
+
     private
 
     PROVIDERS_KEY = '$providers'

--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -626,6 +626,12 @@ module Hako
       # @return [Hash]
       def create_definition(name, container)
         environment = container.env.map { |k, v| { name: k, value: v } }
+        user = container.user
+        # Set user to '0' if not specified, otherwise a new task definition is
+        # always registered because user is set to '0' on a firelens container.
+        # If a user other than root is specified on a firelens container,
+        # registering a task definition fails.
+        user ||= '0' if container.firelens_configuration
         {
           name: name,
           image: container.image_tag,
@@ -645,7 +651,7 @@ module Hako
           linux_parameters: container.linux_parameters,
           depends_on: container.depends_on,
           volumes_from: container.volumes_from,
-          user: container.user,
+          user: user,
           log_configuration: container.log_configuration,
           health_check: container.health_check,
           ulimits: container.ulimits,
@@ -653,6 +659,7 @@ module Hako
           readonly_root_filesystem: container.readonly_root_filesystem,
           docker_security_options: container.docker_security_options,
           system_controls: container.system_controls,
+          firelens_configuration: container.firelens_configuration,
         }
       end
 

--- a/lib/hako/schedulers/ecs_definition_comparator.rb
+++ b/lib/hako/schedulers/ecs_definition_comparator.rb
@@ -46,6 +46,7 @@ module Hako
           struct.member(:readonly_root_filesystem, Schema::Nullable.new(Schema::Boolean.new))
           struct.member(:docker_security_options, Schema::Nullable.new(Schema::UnorderedArray.new(Schema::String.new)))
           struct.member(:system_controls, Schema::Nullable.new(system_controls_schema))
+          struct.member(:firelens_configuration, Schema::Nullable.new(firelens_configuration_schema))
         end
       end
 
@@ -180,6 +181,13 @@ module Hako
         Schema::Structure.new.tap do |struct|
           struct.member(:namespace, Schema::String.new)
           struct.member(:value, Schema::String.new)
+        end
+      end
+
+      def firelens_configuration_schema
+        Schema::Structure.new.tap do |struct|
+          struct.member(:type, Schema::String.new)
+          struct.member(:options, Schema::Nullable.new(Schema::Table.new(Schema::String.new, Schema::String.new)))
         end
       end
     end

--- a/spec/hako/schedulers/ecs_spec.rb
+++ b/spec/hako/schedulers/ecs_spec.rb
@@ -87,6 +87,7 @@ RSpec.describe Hako::Schedulers::Ecs do
         readonly_root_filesystem: nil,
         docker_security_options: nil,
         system_controls: nil,
+        firelens_configuration: nil
       }],
       volumes: [],
       requires_compatibilities: nil,


### PR DESCRIPTION
This adds a new parameter called firelens_configuration, which maps to [ContainerDefinition's firelensConfiguration](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDefinition.html#ECS-Type-ContainerDefinition-firelensConfiguration), to the container definition.

References:
- [ContainerDefinition](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDefinition.html#ECS-Type-ContainerDefinition-firelensConfiguration)
- [FirelensConfiguration](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_FirelensConfiguration.html)
- [Custom Log Routing](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_firelens.html)