### PR TITLE
Support to replace certificate arn in elb_v2 scheduler

### DIFF
--- a/lib/hako/schedulers/ecs_elb_v2.rb
+++ b/lib/hako/schedulers/ecs_elb_v2.rb
@@ -158,6 +158,16 @@ module Hako
                   elb_client.modify_listener(listener_arn: current_listener.listener_arn, ssl_policy: new_listener['ssl_policy'])
                 end
               end
+
+              if current_listener && new_listener['certificate_arn'] && new_listener['certificate_arn'] != current_listener.certificates[0]&.certificate_arn
+                certificates = [{ certificate_arn: new_listener['certificate_arn'] }]
+                if @dry_run
+                  Hako.logger.info("elb_client.modify_listener(listener_arn: #{current_listener.listener_arn}, certificates: #{certificates.inspect}) (dry-run)")
+                else
+                  Hako.logger.info("Updating ELBv2 listener #{new_listener['port']} certificates to #{certificates.inspect}")
+                  elb_client.modify_listener(listener_arn: current_listener.listener_arn, certificates: certificates)
+                end
+              end
             end
           end
 

--- a/spec/hako/schedulers/ecs_spec.rb
+++ b/spec/hako/schedulers/ecs_spec.rb
@@ -341,6 +341,7 @@ RSpec.describe Hako::Schedulers::Ecs do
           listeners << Aws::ElasticLoadBalancingV2::Types::Listener.new(
             listener_arn: "arn:aws:elasticloadbalancing:ap-northeast-1:012345678901:listener/app/#{app.id}/0123456789abcdef/0123456789abcdef",
             port: 80,
+            certificates: [],
           )
           Aws::ElasticLoadBalancingV2::Types::CreateListenerOutput.new(listeners: listeners)
         end.once
@@ -356,6 +357,12 @@ RSpec.describe Hako::Schedulers::Ecs do
             listener_arn: "arn:aws:elasticloadbalancing:ap-northeast-1:012345678901:listener/app/#{app.id}/0123456789abcdef/abcdef0123456789",
             port: 443,
             ssl_policy: 'ELBSecurityPolicy-2016-08',
+            certificates: [
+              Aws::ElasticLoadBalancingV2::Types::Certificate.new(
+                certificate_arn: 'arn:aws:acm:ap-northeast-1:012345678901:certificate/01234567-89ab-cdef-0123-456789abcdef',
+                is_default: false,
+              ),
+            ],
           )
           Aws::ElasticLoadBalancingV2::Types::CreateListenerOutput.new(listeners: listeners)
         end.once


### PR DESCRIPTION
This will help us rotate a third-party certificate.