### PR TITLE
Support tags for task definition and propagate them to ECS tasks

### DIFF
--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -466,7 +466,7 @@ module Hako
       # @param [Array<Hash>] desired_definitions
       # @param [Aws::ECS::Types::TaskDefinition] actual_definition
       # @param [Array<Aws::ECS::Types::Tag>] actual_tags
-      # @return [Array<Boolean]
+      # @return [Array<Boolean>]
       def task_definition_changed?(desired_definitions, actual_definition, actual_tags)
         if @force
           return true

--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -100,6 +100,7 @@ module Hako
         if options['service_discovery']
           @service_discovery = EcsServiceDiscovery.new(options.fetch('service_discovery'), @region, dry_run: @dry_run)
         end
+        @tags = options.fetch('tags', {}).map { |k, v| { key: k, value: v.to_s } }
 
         @started_at = nil
         @container_instance_arn = nil
@@ -464,8 +465,9 @@ module Hako
 
       # @param [Array<Hash>] desired_definitions
       # @param [Aws::ECS::Types::TaskDefinition] actual_definition
+      # @param [Array<Aws::ECS::Types::Tag>] actual_tags
       # @return [Array<Boolean]
-      def task_definition_changed?(desired_definitions, actual_definition)
+      def task_definition_changed?(desired_definitions, actual_definition, actual_tags)
         if @force
           return true
         end
@@ -513,6 +515,11 @@ module Hako
         if actual_definition.requires_compatibilities != @requires_compatibilities
           return true
         end
+        actual_tags_set = Set.new(actual_tags.map { |t| {key: t.key, value: t.value } })
+        tags_set = Set.new(@tags)
+        if actual_tags_set != tags_set
+          return true
+        end
 
         false
       end
@@ -535,7 +542,10 @@ module Hako
       # @return [Array<Boolean, Aws::ECS::Types::TaskDefinition>]
       def register_task_definition(definitions)
         current_task_definition = describe_task_definition(@app_id)
-        if task_definition_changed?(definitions, current_task_definition)
+        if current_task_definition
+          current_tags = ecs_client.list_tags_for_resource(resource_arn: current_task_definition.task_definition_arn).tags
+        end
+        if task_definition_changed?(definitions, current_task_definition, current_tags)
           new_task_definition = ecs_client.register_task_definition(
             family: @app_id,
             task_role_arn: @task_role_arn,
@@ -546,6 +556,7 @@ module Hako
             requires_compatibilities: @requires_compatibilities,
             cpu: @cpu,
             memory: @memory,
+            tags: @tags.empty? ? nil : @tags,
           ).task_definition
           [true, new_task_definition]
         else
@@ -568,7 +579,10 @@ module Hako
           begin
             family = "#{@app_id}-oneshot"
             current_task_definition = describe_task_definition(family)
-            if task_definition_changed?(definitions, current_task_definition)
+            if current_task_definition
+              current_tags = ecs_client.list_tags_for_resource(resource_arn: current_task_definition.task_definition_arn).tags
+            end
+            if task_definition_changed?(definitions, current_task_definition, current_tags)
               new_task_definition = ecs_client.register_task_definition(
                 family: family,
                 task_role_arn: @task_role_arn,
@@ -579,6 +593,7 @@ module Hako
                 requires_compatibilities: @requires_compatibilities,
                 cpu: @cpu,
                 memory: @memory,
+                tags: @tags.empty? ? nil : @tags,
               ).task_definition
               return [true, new_task_definition]
             else
@@ -682,6 +697,7 @@ module Hako
           capacity_provider_strategy: @capacity_provider_strategy,
           platform_version: @platform_version,
           network_configuration: @network_configuration,
+          propagate_tags: 'TASK_DEFINITION',
         )
         result.failures.each do |failure|
           Hako.logger.error("#{failure.arn} #{failure.reason}")
@@ -924,6 +940,7 @@ module Hako
           platform_version: @platform_version,
           network_configuration: @network_configuration,
           health_check_grace_period_seconds: @health_check_grace_period_seconds,
+          propagate_tags: 'TASK_DEFINITION',
         }
         if @scheduling_strategy != 'DAEMON'
           params[:desired_count] = 0

--- a/spec/hako/schedulers/ecs_spec.rb
+++ b/spec/hako/schedulers/ecs_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Hako::Schedulers::Ecs do
       platform_version: nil,
       network_configuration: nil,
       health_check_grace_period_seconds: nil,
+      propagate_tags: 'TASK_DEFINITION',
     }
   end
   let(:update_service_params) do
@@ -94,6 +95,7 @@ RSpec.describe Hako::Schedulers::Ecs do
       requires_compatibilities: nil,
       cpu: nil,
       memory: nil,
+      tags: nil,
     }
   end
   let(:dummy_service_response) do
@@ -185,6 +187,7 @@ RSpec.describe Hako::Schedulers::Ecs do
             volumes: [],
           ),
         )).once
+        allow(ecs_client).to receive(:list_tags_for_resource).with(resource_arn: task_definition_arn).and_return(Aws::ECS::Types::ListTagsForResourceResponse.new(tags: [])).once
       end
 
       it 'does nothing' do
@@ -210,6 +213,7 @@ RSpec.describe Hako::Schedulers::Ecs do
             volumes: [],
           ),
         )).once
+        allow(ecs_client).to receive(:list_tags_for_resource).with(resource_arn: task_definition_arn).and_return(Aws::ECS::Types::ListTagsForResourceResponse.new(tags: [])).once
       end
 
       it 'updates service' do
@@ -241,6 +245,7 @@ RSpec.describe Hako::Schedulers::Ecs do
             volumes: [],
           ),
         )).once
+        allow(ecs_client).to receive(:list_tags_for_resource).with(resource_arn: running_task_definition_arn).and_return(Aws::ECS::Types::ListTagsForResourceResponse.new(tags: [])).once
       end
       it 'updates task definition and service' do
         expect(ecs_client).to receive(:register_task_definition).with(register_task_definition_params).and_return(Aws::ECS::Types::RegisterTaskDefinitionResponse.new(
@@ -273,6 +278,7 @@ RSpec.describe Hako::Schedulers::Ecs do
       before do
         allow(ecs_client).to receive(:describe_services).with(cluster: 'eagletmt', services: [app.id]).and_return(Aws::ECS::Types::DescribeServicesResponse.new(failures: [], services: [])).once
         allow(ecs_client).to receive(:describe_task_definition).with(task_definition: app.id).and_raise(Aws::ECS::Errors::ClientException.new(nil, 'Unable to describe task definition')).once
+        allow(ecs_client).to receive(:list_tags_for_resource).with(resource_arn: task_definition_arn).and_return(Aws::ECS::Types::ListTagsForResourceResponse.new(tags: [])).once
 
         allow(Aws::ElasticLoadBalancingV2::Client).to receive(:new).and_return(elb_v2_client)
         @created_load_balancer = nil
@@ -410,6 +416,7 @@ RSpec.describe Hako::Schedulers::Ecs do
       before do
         allow(ecs_client).to receive(:describe_services).with(cluster: 'eagletmt', services: [app.id]).and_return(Aws::ECS::Types::DescribeServicesResponse.new(failures: [], services: [])).once
         allow(ecs_client).to receive(:describe_task_definition).with(task_definition: app.id).and_raise(Aws::ECS::Errors::ClientException.new(nil, 'Unable to describe task definition')).once
+        allow(ecs_client).to receive(:list_tags_for_resource).with(resource_arn: task_definition_arn).and_return(Aws::ECS::Types::ListTagsForResourceResponse.new(tags: [])).once
 
         allow(Aws::ServiceDiscovery::Client).to receive(:new).and_return(service_discovery_client)
         namespace = Aws::ServiceDiscovery::Types::Namespace.new(type: 'DNS_PRIVATE')
@@ -523,6 +530,7 @@ RSpec.describe Hako::Schedulers::Ecs do
             volumes: [],
           ),
         )).once
+        allow(ecs_client).to receive(:list_tags_for_resource).with(resource_arn: task_definition_arn).and_return(Aws::ECS::Types::ListTagsForResourceResponse.new(tags: [])).once
         allow(ecs_client).to receive(:run_task).with(
           cluster: 'eagletmt',
           task_definition: task_definition_arn,
@@ -534,6 +542,7 @@ RSpec.describe Hako::Schedulers::Ecs do
           capacity_provider_strategy: nil,
           platform_version: nil,
           network_configuration: nil,
+          propagate_tags: 'TASK_DEFINITION',
         ).and_return(Aws::ECS::Types::RunTaskResponse.new(
           failures: [],
           tasks: [


### PR DESCRIPTION
# Motivation

[Cost allocation tags feature of AWS](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html) is useful to understand cost condition. In general, also tags are useful for metadata of AWS resources.

ECS supports tagging for task definitions, tasks and services. Tags attached to task definition and service can be propagated to its related running tasks. cf. https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-using-tags.html

This patch adds a support tagging for task definitions and propagate these tags to tasks generated from that definition.

# What not to do

This change doesn't support tagging for services and propagate tags only from task definitions (it means no service propagate tags).

This is for simplicity of implementation and specification of Hako. When we use Hako, 1 hako app has 1 service and 1 task definition basically. So it's enough define tags to a task definition and propagate them to running tasks generated from the definition. I think this is natural and it can cover general use-cases.

# Hako config

```jsonnet
{
  scheduler: {
    type: 'ecs',
    tags: {
      Project: 'awesome-project',
    },
  },
}
```

@eagletmt Please review 🙏