### PR TITLE
Add alternative to run hako in a docker contaier

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM ruby:2.5
+
+WORKDIR /usr/src/app
+COPY . .
+RUN bin/setup
+RUN bundle exec rake install
+
+ENTRYPOINT [ "/usr/local/bundle/bin/hako" ]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ Or install it yourself as:
 
     $ gem install hako
 
+Or run it in a docker container:
+
+    $ docker build -t hako .
+    $ docker run -it --rm hako --help
+
 ## Usage
 
 ```


### PR DESCRIPTION
Hi,

I've created a Dockerfile, so that it is possible to build a docker container and run it in a container, without the need of a local ruby installation.