### PR TITLE
Support protocol_version and matcher option of target groups

### DIFF
--- a/examples/hello-grpc.jsonnet
+++ b/examples/hello-grpc.jsonnet
@@ -1,0 +1,60 @@
+{
+  scheduler: {
+    type: 'ecs',
+    region: 'ap-northeast-1',
+    cluster: 'eagletmt',
+    desired_count: 2,
+    role: 'ecsServiceRole',
+    elb_v2: {
+      // Specify protocol_version for gRPC servers
+      protocol_version: 'GRPC',
+      // VPC id where the target group is located
+      vpc_id: 'vpc-WWWWWWWW',
+      // If you want internal ELB, then use 'scheme'. (ex. internal service that like microservice inside VPC)
+      scheme: 'internal',
+      // Health check path of the target group
+      health_check_path: '/AWS.ELB/healthcheck',
+      listeners: [
+        {
+          port: 50051,
+          protocol: 'HTTPS',
+          certificate_arn: 'arn:aws:acm:ap-northeast-1:012345678901:certificate/01234567-89ab-cdef-0123-456789abcdef',
+        },
+      ],
+      subnets: ['subnet-XXXXXXXX', 'subnet-YYYYYYYY'],
+      security_groups: ['sg-ZZZZZZZZ'],
+      load_balancer_attributes: {
+        'access_logs.s3.enabled': 'true',
+        'access_logs.s3.bucket': 'hako-access-logs',
+        'access_logs.s3.prefix': 'hako-hello-grpc',
+      },
+      target_group_attributes: {
+        // http://docs.aws.amazon.com/en_us/elasticloadbalancing/latest/application/load-balancer-target-groups.html#target-group-attributes
+        'deregistration_delay.timeout_seconds': '20',
+      },
+      // Route ELB traffic to app container directly
+      container_name: 'app',
+      container: 50051,
+    },
+  },
+  app: {
+    image: 'awesome-grpc-server',
+    memory: 128,
+    cpu: 256,
+    env: {
+      PORT: '50051',
+    },
+    secrets: [{
+      name: 'MESSAGE',
+      value_from: 'arn:aws:ssm:ap-northeast-1:012345678901:parameter/hako/hello-grpc/secret-message',
+    }],
+    port_mappings: [
+      {
+        container_port: 50051,
+        host_port: 0,
+        protocol: 'tcp',
+      },
+    ],
+  },
+  scripts: [],
+}

--- a/hako.gemspec
+++ b/hako.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'aws-sdk-ec2'
   spec.add_dependency 'aws-sdk-ecs', '>= 1.54.0'
   spec.add_dependency 'aws-sdk-elasticloadbalancing'
-  spec.add_dependency 'aws-sdk-elasticloadbalancingv2'
+  spec.add_dependency 'aws-sdk-elasticloadbalancingv2', '>= 1.54.0'
   spec.add_dependency 'aws-sdk-s3'
   spec.add_dependency 'aws-sdk-servicediscovery'
   spec.add_dependency 'aws-sdk-sns'

--- a/lib/hako/schedulers/ecs_elb_v2.rb
+++ b/lib/hako/schedulers/ecs_elb_v2.rb
@@ -89,13 +89,22 @@ module Hako
                              target_type: @elb_v2_config.fetch('target_type', nil),
                            ).target_groups[0]
                          else
+                           matcher =
+                             if @elb_v2_config.key?('matcher')
+                               {
+                                 http_code: @elb_v2_config.fetch('matcher')['http_code'],
+                                 grpc_code: @elb_v2_config.fetch('matcher')['grpc_code'],
+                               }
+                             end
                            elb_client.create_target_group(
                              name: target_group_name,
                              port: 80,
                              protocol: 'HTTP',
+                             protocol_version: @elb_v2_config.fetch('protocol_version', 'HTTP1'),
                              vpc_id: @elb_v2_config.fetch('vpc_id'),
                              health_check_path: @elb_v2_config.fetch('health_check_path', nil),
                              target_type: @elb_v2_config.fetch('target_type', nil),
+                             matcher: matcher,
                            ).target_groups[0]
                          end
 

--- a/spec/hako/schedulers/ecs_spec.rb
+++ b/spec/hako/schedulers/ecs_spec.rb
@@ -332,9 +332,11 @@ RSpec.describe Hako::Schedulers::Ecs do
           name: "hako-#{app.id}",
           port: 80,
           protocol: 'HTTP',
+          protocol_version: 'HTTP1',
           vpc_id: 'vpc-11111111',
           health_check_path: '/site/sha',
           target_type: nil,
+          matcher: nil,
         ) {
           target_group = Aws::ElasticLoadBalancingV2::Types::TargetGroup.new(target_group_arn: target_group_arn)
           target_groups << target_group


### PR DESCRIPTION
https://aws.amazon.com/jp/blogs/aws/new-application-load-balancer-support-for-end-to-end-http-2-and-grpc/