### PR TITLE
Run sidecars referenced by depends_on on hako oneshot

### DIFF
--- a/lib/hako/definition_loader.rb
+++ b/lib/hako/definition_loader.rb
@@ -58,6 +58,10 @@ module Hako
           containers[name].volumes_from.each do |volumes_from|
             names << volumes_from[:source_container]
           end
+
+          containers[name].depends_on&.each do |depends_on|
+            names << depends_on[:container_name]
+          end
         end
       end
       containers

--- a/spec/fixtures/jsonnet/default_with_depends_on.jsonnet
+++ b/spec/fixtures/jsonnet/default_with_depends_on.jsonnet
@@ -1,0 +1,25 @@
+{
+  app: {
+    image: 'app-image',
+    depends_on: [
+      { container_name: 'redis', condition: 'STARTED' },
+    ],
+  },
+  sidecars: {
+    redis: {
+      image_tag: 'redis',
+      depends_on: [
+        { container_name: 'memcached', condition: 'STARTED' },
+      ],
+    },
+    memcached: {
+      image_tag: 'memcached',
+    },
+    fluentd: {
+      image_tag: 'fluentd',
+      depends_on: [
+        { container_name: 'redis', condition: 'STARTED' },
+      ],
+    },
+  },
+}

--- a/spec/hako/definition_loader_spec.rb
+++ b/spec/hako/definition_loader_spec.rb
@@ -63,5 +63,22 @@ RSpec.describe Hako::DefinitionLoader do
         end
       end
     end
+
+    context 'with depends_on' do
+      let(:fixture_name) { 'default_with_depends_on.jsonnet' }
+
+      it 'loads all containers' do
+        containers = definition_loader.load
+        expect(containers.keys).to match_array(%w[app redis memcached fluentd])
+        expect(containers.values).to all(be_a(Hako::Container))
+      end
+
+      context 'with `with`' do
+        it 'loads specified definition and referenced containers' do
+          containers = definition_loader.load(with: [])
+          expect(containers.keys).to match_array(%w[app redis memcached])
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Sidecars referenced by `depends_on` from the specified containers have to be run along with them when running `hako oneshot`, otherwise a RegisterTaskDefinition API call fails with something along the lines of:

```
Aws::ECS::Errors::ClientException: Cannot depend on container + 'sidecar-container' because it does not exist
```