### PR TITLE
Support efs_volume_configuration parameter in v2.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.16.0 (2021-01-21)
+## New features
+- Support `efs_volume_configuration` parameter
+
 # 2.15.0 (2020-11-02)
 ## New features
 - Support protocol_version and matcher option of ALB target groups

--- a/lib/hako/schedulers/ecs_volume_comparator.rb
+++ b/lib/hako/schedulers/ecs_volume_comparator.rb
@@ -37,6 +37,23 @@ module Hako
         end
       end
 
+      def efs_volume_configuration_schema
+        Schema::Structure.new.tap do |struct|
+          struct.member(:authorization_config, Schema::Nullable.new(efs_authorization_config_schema))
+          struct.member(:file_system_id, Schema::String.new)
+          struct.member(:root_directory, Schema::Nullable.new(Schema::String.new))
+          struct.member(:transit_encryption, Schema::Nullable.new(Schema::String.new))
+          struct.memberr(:transit_encryption_port, Schema::Nullable.new(Schema::Integer.new))
+        end
+      end
+
+      def efs_authorization_config_schema
+        Schema::Structure.new.tap do |struct|
+          struct.member(:access_point_id, Schema::Nullable.new(Schema::String.new))
+          struct.member(:iam, Schema::Nullable.new(Schema::String.new))
+        end
+      end
+
       def host_schema
         Schema::Structure.new.tap do |struct|
           struct.member(:source_path, Schema::Nullable.new(Schema::String.new))

--- a/lib/hako/version.rb
+++ b/lib/hako/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Hako
-  VERSION = '2.15.0'
+  VERSION = '2.16.0'
 end

--- a/spec/hako/schedulers/ecs_volume_comparator_spec.rb
+++ b/spec/hako/schedulers/ecs_volume_comparator_spec.rb
@@ -18,6 +18,16 @@ RSpec.describe Hako::Schedulers::EcsVolumeComparator do
           'foo' => 'bar',
         },
       },
+      efs_volume_configuration: {
+        authorization_config: {
+          access_point_id: 'foo',
+          iam: 'foo',
+        },
+        file_system_id: 'foo',
+        root_directory: '/foo',
+        transit_encryption: 'DISABLED',
+        transit_encryption_port: 1234,
+      },
       host: {
         source_path: '/tmp',
       },
@@ -37,6 +47,16 @@ RSpec.describe Hako::Schedulers::EcsVolumeComparator do
           'foo' => 'bar',
         },
         scope: 'task',
+      ),
+      efs_volume_configuration: Aws::ECS::Types::EFSVolumeConfiguration.new(
+        authorization_config: Aws::ECS::Types::EFSAuthorizationConfig.new(
+          access_point_id: 'foo',
+          iam: 'foo',
+        ),
+        file_system_id: 'foo',
+        root_directory: '/foo',
+        transit_encryption: 'DISABLED',
+        transit_encryption_port: 1234,
       ),
       host: Aws::ECS::Types::HostVolumeProperties.new(
         source_path: '/tmp',


### PR DESCRIPTION
Amazon ECS supports Amazon EFS File Systems [since April, 2020](https://aws.amazon.com/about-aws/whats-new/2020/04/amazon-ecs-aws-fargate-support-amazon-efs-filesystems-generally-available/). This PR adds support for configuring [EFSVolumeConfiguration](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_EFSVolumeConfiguration.html) parameter for ECS API.

## Documentation

- [Amazon EFS Volumes on Amazon ECS](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/efs-volumes.html)
- ECS API 
  - [Volume](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Volume.html)
  - [EFSVolumeConfiguration](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_EFSVolumeConfiguration.html)

## Expected Configuration

```jsonnet
  volumes: {
    my-efs: {
      efs_volume_configuration: {
        authorization_config: {
          access_point_id: 'foo',
          iam: 'foo',
        },
        file_system_id: 'TODO',
        root_directory: '/foo',
        transit_encryption: 'ENABLED',
        transit_encryption_port: 1234,
      },
    },
```