### PR TITLE
support for healthcheck parameters for elbv2 target groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 2.16.0 (2020-11-02)
+## New features
+- Support for parameters in elbv2 
+  - `health_check_timeout_seconds`
+  - `health_check_interval_seconds`
+  - `healthy_threshold_count`
+  - `unhealthy_threshold_count`
+
 # 2.15.0 (2020-11-02)
 ## New features
 - Support protocol_version and matcher option of ALB target groups

--- a/examples/hello-lb-v2.jsonnet
+++ b/examples/hello-lb-v2.jsonnet
@@ -15,6 +15,14 @@
       // scheme: internal
       // Health check path of the target group
       health_check_path: '/site/sha',
+      // Health check timeout of the target group
+      health_check_timeout_seconds: 5,
+      // Health check interval of the target group
+      health_check_interval_seconds: 30,
+      // Required successful health check requests to targets to become healthy
+      healthy_threshold_count: 5,
+      // Target group consecutive failed health checks before considered unhealthy
+      unhealthy_threshold_count: 2,
       listeners: [
         {
           port: 80,

--- a/lib/hako/schedulers/ecs_elb_v2.rb
+++ b/lib/hako/schedulers/ecs_elb_v2.rb
@@ -87,6 +87,8 @@ module Hako
                              protocol: 'TCP',
                              vpc_id: @elb_v2_config.fetch('vpc_id'),
                              target_type: @elb_v2_config.fetch('target_type', nil),
+                             healthy_threshold_count: @elb_v2_config.fetch('healthy_threshold_count', nil),
+                             unhealthy_threshold_count: @elb_v2_config.fetch('unhealthy_threshold_count', nil),
                            ).target_groups[0]
                          else
                            matcher =
@@ -103,6 +105,10 @@ module Hako
                              protocol_version: @elb_v2_config.fetch('protocol_version', 'HTTP1'),
                              vpc_id: @elb_v2_config.fetch('vpc_id'),
                              health_check_path: @elb_v2_config.fetch('health_check_path', nil),
+                             health_check_timeout_seconds: @elb_v2_config.fetch('health_check_timeout_seconds', nil),
+                             healthy_threshold_count: @elb_v2_config.fetch('healthy_threshold_count', nil),
+                             health_check_interval_seconds: elb_v2_config.fetch('health_check_interval_seconds', nil),
+                             unhealthy_threshold_count: elb_v2_config.fetch('unhealthy_threshold_count', nil),
                              target_type: @elb_v2_config.fetch('target_type', nil),
                              matcher: matcher,
                            ).target_groups[0]

--- a/lib/hako/schedulers/ecs_elb_v2.rb
+++ b/lib/hako/schedulers/ecs_elb_v2.rb
@@ -206,6 +206,25 @@ module Hako
               elb_client.modify_target_group_attributes(target_group_arn: target_group.target_group_arn, attributes: attributes)
             end
           end
+          # modify health_check_path
+          if @elb_v2_config.key?('health_check_path')
+            target_group = describe_target_group
+            attributes = @elb_v2_config.fetch('health_check_path')
+            if @dry_run
+              if target_group
+                Hako.logger.info("elb_client.modify_target_group(target_group_arn: #{target_group.target_group_arn}, health_check_path: #{health_check_path}) (dry-run)")
+              else
+                Hako.logger.info("elb_client.modify_target_group_attributes(target_group_arn: unknown, attributes: #{attributes.inspect}) (dry-run)")
+              end
+            else
+              Hako.logger.info("Updating target group health_check_path to #{health_check_path}")
+              elb_client.modify_target_group(target_group_arn: target_group.target_group_arn, health_check_path: health_check_path)
+            end
+          end
+          # TODO modify health_check_timeout_seconds
+          # TODO modify healthy_threshold_count
+          # TODO modify health_check_interval_seconds
+          # TODO modify unhealthy_threshold_count
         end
         nil
       end

--- a/lib/hako/schedulers/ecs_elb_v2.rb
+++ b/lib/hako/schedulers/ecs_elb_v2.rb
@@ -107,8 +107,8 @@ module Hako
                              health_check_path: @elb_v2_config.fetch('health_check_path', nil),
                              health_check_timeout_seconds: @elb_v2_config.fetch('health_check_timeout_seconds', nil),
                              healthy_threshold_count: @elb_v2_config.fetch('healthy_threshold_count', nil),
-                             health_check_interval_seconds: elb_v2_config.fetch('health_check_interval_seconds', nil),
-                             unhealthy_threshold_count: elb_v2_config.fetch('unhealthy_threshold_count', nil),
+                             health_check_interval_seconds: @elb_v2_config.fetch('health_check_interval_seconds', nil),
+                             unhealthy_threshold_count: @elb_v2_config.fetch('unhealthy_threshold_count', nil),
                              target_type: @elb_v2_config.fetch('target_type', nil),
                              matcher: matcher,
                            ).target_groups[0]
@@ -206,28 +206,84 @@ module Hako
               elb_client.modify_target_group_attributes(target_group_arn: target_group.target_group_arn, attributes: attributes)
             end
           end
-          # modify health_check_path
-          if @elb_v2_config.key?('health_check_path')
+          # modify health_check_timeout
+          if @elb_v2_config.key?('health_check_timeout_seconds')
             target_group = describe_target_group
-            attributes = @elb_v2_config.fetch('health_check_path')
+            health_check_timeout_seconds = @elb_v2_config.fetch('health_check_timeout_seconds')
             if @dry_run
               if target_group
-                Hako.logger.info("elb_client.modify_target_group(target_group_arn: #{target_group.target_group_arn}, health_check_path: #{health_check_path}) (dry-run)")
+                Hako.logger.info("elb_client.modify_target_group(target_group_arn: #{target_group.target_group_arn}, health_check_timeout_seconds: #{health_check_timeout_seconds}) (dry-run)")
               else
-                Hako.logger.info("elb_client.modify_target_group_attributes(target_group_arn: unknown, attributes: #{attributes.inspect}) (dry-run)")
+                Hako.logger.info("elb_client.modify_target_group(#{target_group.target_group_arn}, health_check_timeout_seconds: #{health_check_timeout_seconds}) (dry-run)")
               end
             else
-              Hako.logger.info("Updating target group health_check_path to #{health_check_path}")
-              elb_client.modify_target_group(target_group_arn: target_group.target_group_arn, health_check_path: health_check_path)
+              Hako.logger.info("Updating target group health_check_timeout_seconds to #{health_check_timeout_seconds}")
+              elb_client.modify_target_group(target_group_arn: target_group.target_group_arn, health_check_timeout_seconds: health_check_timeout_seconds)
             end
           end
-          # TODO modify health_check_timeout_seconds
-          # TODO modify healthy_threshold_count
-          # TODO modify health_check_interval_seconds
-          # TODO modify unhealthy_threshold_count
+          # modify healthy_threshold_count
+          if @elb_v2_config.key?('healthy_threshold_count')
+            target_group = describe_target_group
+            healthy_threshold_count = @elb_v2_config.fetch('healthy_threshold_count')
+            if @dry_run
+              if target_group
+                Hako.logger.info("elb_client.modify_target_group(target_group_arn: #{target_group.target_group_arn}, healthy_threshold_count: #{healthy_threshold_count}) (dry-run)")
+              else
+                Hako.logger.info("elb_client.modify_target_group(#{target_group.target_group_arn}, healthy_threshold_count: #{healthy_threshold_count}) (dry-run)")
+              end
+            else
+              Hako.logger.info("Updating target group healthy_threshold_count to #{healthy_threshold_count}")
+              elb_client.modify_target_group(target_group_arn: target_group.target_group_arn, healthy_threshold_count: healthy_threshold_count)
+            end
+          end
+          # modify health_check_interval_seconds
+          if @elb_v2_config.key?('health_check_interval_seconds')
+            target_group = describe_target_group
+            health_check_interval_seconds = @elb_v2_config.fetch('health_check_interval_seconds')
+            if @dry_run
+              if target_group
+                Hako.logger.info("elb_client.modify_target_group(target_group_arn: #{target_group.target_group_arn}, health_check_interval_seconds: #{health_check_interval_seconds}) (dry-run)")
+              else
+                Hako.logger.info("elb_client.modify_target_group(#{target_group.target_group_arn}, health_check_interval_seconds: #{health_check_interval_seconds}) (dry-run)")
+              end
+            else
+              Hako.logger.info("Updating target group health_check_interval_seconds to #{health_check_interval_seconds}")
+              elb_client.modify_target_group(target_group_arn: target_group.target_group_arn, health_check_interval_seconds: health_check_interval_seconds)
+            end
+          end
+          # modify unhealthy_threshold_count
+          if @elb_v2_config.key?('unhealthy_threshold_count')
+            target_group = describe_target_group
+            unhealthy_threshold_count = @elb_v2_config.fetch('unhealthy_threshold_count')
+            if @dry_run
+              if target_group
+                Hako.logger.info("elb_client.modify_target_group(target_group_arn: #{target_group.target_group_arn}, unhealthy_threshold_count: #{unhealthy_threshold_count}) (dry-run)")
+              else
+                Hako.logger.info("elb_client.modify_target_group(#{target_group.target_group_arn}, unhealthy_threshold_count: #{unhealthy_threshold_count}) (dry-run)")
+              end
+            else
+              Hako.logger.info("Updating target group unhealthy_threshold_count to #{unhealthy_threshold_count}")
+              elb_client.modify_target_group(target_group_arn: target_group.target_group_arn, unhealthy_threshold_count: unhealthy_threshold_count)
+            end
+          end
         end
         nil
       end
+      
+      def modify_health_check(target_group, health_check_parameter)
+        health_check_value = @elb_v2_config.fetch(health_check_parameter)
+        if @dry_run
+          if target_group
+            Hako.logger.info("elb_client.modify_target_group(target_group_arn: #{target_group.target_group_arn}, #{health_check_parameter}: #{health_check_value}) (dry-run)")
+          else
+            Hako.logger.info("elb_client.modify_target_group(#{target_group.target_group_arn}, #{health_check_parameter}: #{health_check_value}) (dry-run)")
+          end
+        else
+          Hako.logger.info("Updating target group #{health_check_parameter} to #{health_check_value}")
+          elb_client.modify_target_group(target_group_arn: target_group.target_group_arn, health_check_parameter: health_check_value)
+        end
+      end
+
 
       # @return [nil]
       def destroy

--- a/spec/hako/schedulers/ecs_spec.rb
+++ b/spec/hako/schedulers/ecs_spec.rb
@@ -337,6 +337,10 @@ RSpec.describe Hako::Schedulers::Ecs do
           health_check_path: '/site/sha',
           target_type: nil,
           matcher: nil,
+          healthy_threshold_count: nil,
+          unhealthy_threshold_count: nil,
+          health_check_interval_seconds: nil,
+          health_check_timeout_seconds: nil,
         ) {
           target_group = Aws::ElasticLoadBalancingV2::Types::TargetGroup.new(target_group_arn: target_group_arn)
           target_groups << target_group


### PR DESCRIPTION
This PR adds support for the following parameters for elbv2:

  - `health_check_timeout_seconds`
  - `health_check_interval_seconds`
  - `healthy_threshold_count`
  - `unhealthy_threshold_count`

to configure healthcheck behaviour in ELB target groups
