### PR TITLE
Support new option 'ephemeralStorage' for ECS fargate

### DIFF
--- a/examples/hello-fargate-batch.jsonnet
+++ b/examples/hello-fargate-batch.jsonnet
@@ -7,6 +7,9 @@
     execution_role_arn: 'arn:aws:iam::012345678901:role/ecsTaskExecutionRole',
     cpu: '1024',
     memory: '2048',
+    ephemeral_storage: {
+      size_in_gi_b: '25',
+    },
     requires_compatibilities: ['FARGATE'],
     network_mode: 'awsvpc',
     launch_type: 'FARGATE',

--- a/examples/hello-fargate.jsonnet
+++ b/examples/hello-fargate.jsonnet
@@ -51,6 +51,9 @@ local awslogs = {
     execution_role_arn: 'arn:aws:iam::012345678901:role/ecsTaskExecutionRole',
     cpu: '1024',
     memory: '2048',
+    ephemeral_storage: {
+      size_in_gi_b: '25',
+    },
     requires_compatibilities: ['FARGATE'],
     network_mode: 'awsvpc',
     launch_type: 'FARGATE',

--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -72,6 +72,14 @@ module Hako
         @execution_role_arn = options.fetch('execution_role_arn', nil)
         @cpu = options.fetch('cpu', nil)
         @memory = options.fetch('memory', nil)
+        if options.key?('ephemeral_storage')
+          ephemeral_storage = options.fetch('ephemeral_storage')
+          if ephemeral_storage.key?('size_in_gi_b')
+            @ephemeral_storage = {
+              size_in_gi_b: ephemeral_storage.fetch('size_in_gi_b')
+            }
+          end
+        end
         @requires_compatibilities = options.fetch('requires_compatibilities', nil)
         @launch_type = options.fetch('launch_type', nil)
         if options.key?('capacity_provider_strategy')
@@ -515,6 +523,9 @@ module Hako
         if actual_definition.requires_compatibilities != @requires_compatibilities
           return true
         end
+        if actual_definition.ephemeral_storage != @ephemeral_storage
+          return true
+        end
 
         actual_tags_set = Set.new(actual_tags.map { |t| { key: t.key, value: t.value } })
         tags_set = Set.new(@tags)
@@ -557,6 +568,7 @@ module Hako
             requires_compatibilities: @requires_compatibilities,
             cpu: @cpu,
             memory: @memory,
+            ephemeral_storage: @ephemeral_storage,
             tags: @tags.empty? ? nil : @tags,
           ).task_definition
           [true, new_task_definition]
@@ -593,6 +605,7 @@ module Hako
               requires_compatibilities: @requires_compatibilities,
               cpu: @cpu,
               memory: @memory,
+              ephemeral_storage: @ephemeral_storage,
               tags: @tags.empty? ? nil : @tags,
             ).task_definition
             return [true, new_task_definition]

--- a/spec/hako/schedulers/ecs_spec.rb
+++ b/spec/hako/schedulers/ecs_spec.rb
@@ -96,6 +96,7 @@ RSpec.describe Hako::Schedulers::Ecs do
       requires_compatibilities: nil,
       cpu: nil,
       memory: nil,
+      ephemeral_storage: nil,
       tags: nil,
     }
   end


### PR DESCRIPTION
I have added support for the `ephemeralStorage` option to the ECS scheduler, which is valid in Fargate environments.
The restrictions can be found at [Task definition parameters - Amazon Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_definition_ephemeralStorage)
This option is used when the default 20 GiB is not enough disk space.