### PR TITLE
Attach an EBS volume to the task

### DIFF
--- a/lib/hako/schedulers/ecs.rb
+++ b/lib/hako/schedulers/ecs.rb
@@ -115,6 +115,7 @@ module Hako
         if options['service_discovery']
           @service_discovery = EcsServiceDiscovery.new(options.fetch('service_discovery'), @region, dry_run: @dry_run)
         end
+        @volume_configurations = options.fetch('volume_configurations', nil)
         @tags = options.fetch('tags', {}).map { |k, v| { key: k, value: v.to_s } }
 
         @started_at = nil
@@ -669,6 +670,8 @@ module Hako
               transit_encryption_port: configuration['transit_encryption_port'],
               authorization_config: authorization_config,
             }
+          elsif volume.key?('configured_at_launch')
+            definition[:configured_at_launch] = volume['configured_at_launch']
           else
             # When neither 'host' nor 'docker_volume_configuration' is
             # specified, ECS API treats it as if 'host' is specified without
@@ -741,6 +744,7 @@ module Hako
           platform_version: @platform_version,
           network_configuration: @network_configuration,
           propagate_tags: 'TASK_DEFINITION',
+          volume_configurations: @volume_configurations,
         )
         result.failures.each do |failure|
           Hako.logger.error("#{failure.arn} #{failure.reason}")
@@ -937,6 +941,7 @@ module Hako
           platform_version: @platform_version,
           network_configuration: @network_configuration,
           health_check_grace_period_seconds: @health_check_grace_period_seconds,
+          volume_configurations: @volume_configurations,
         }
         if @autoscaling
           # Keep current desired_count if autoscaling is enabled
@@ -984,6 +989,7 @@ module Hako
           network_configuration: @network_configuration,
           health_check_grace_period_seconds: @health_check_grace_period_seconds,
           propagate_tags: 'TASK_DEFINITION',
+          volume_configurations: @volume_configurations,
         }
         if @scheduling_strategy != 'DAEMON'
           params[:desired_count] = 0

--- a/lib/hako/schedulers/ecs_service_comparator.rb
+++ b/lib/hako/schedulers/ecs_service_comparator.rb
@@ -27,6 +27,7 @@ module Hako
           struct.member(:platform_version, Schema::WithDefault.new(Schema::String.new, 'LATEST'))
           struct.member(:network_configuration, Schema::Nullable.new(network_configuration_schema))
           struct.member(:health_check_grace_period_seconds, Schema::Nullable.new(Schema::Integer.new))
+          struct.member(:volume_configurations, Schema::Nullable.new(volume_configurations_schema))
         end
       end
 
@@ -64,6 +65,45 @@ module Hako
           maximum_percent: 200,
           minimum_healthy_percent: 100,
         }
+      end
+
+      def volume_configurations_schema
+        Schema::Structure.new.tap do |struct|
+          struct.member(:name, Schema::String.new)
+          struct.member(:managed_ebs_volume, Schema::Nullable.new(managed_ebs_volume_schema))
+        end
+      end
+
+      def managed_ebs_volume_schema
+        Schema::Structure.new.tap do |struct|
+          struct.member(:encrypted, Schema::Nullable.new(Schema::Boolean.new))
+          struct.member(:kms_key_id, Schema::Nullable.new(Schema::String.new))
+          struct.member(:volume_type, Schema::Nullable.new(Schema::String.new))
+          struct.member(:size_in_gi_b, Schema::Nullable.new(Schema::Integer.new))
+          struct.member(:snapshot_id, Schema::Nullable.new(Schema::String.new))
+          struct.member(:iops, Schema::Nullable.new(Schema::Integer.new))
+          struct.member(:throughput, Schema::Nullable.new(Schema::Integer.new))
+          struct.member(:role_arn, Schema::String.new)
+          struct.member(:tag_specifications, Schema::Nullable.new(tag_specifications_schema))
+          struct.member(:file_system_type, Schema::Nullable.new(Schema::String.new))
+        end
+      end
+
+      def tag_specifications_schema
+        Schema::Structure.new.tap do |struct|
+          struct.member(:resource_type, Schema::String.new)
+          struct.member(:tags, Schema::Nullable.new(tags_schema))
+          struct.member(:propatage_tags, Schema::Nullable.new(Schema::String.new))
+        end
+      end
+
+      def tags_schema
+        Schema::UnorderedArray.new(
+          Schema::Structure.new.tap do |struct|
+            struct.member(:key, Schema::String.new)
+            struct.member(:value, Schema::String.new)
+          end
+        )
       end
     end
   end

--- a/lib/hako/schedulers/ecs_volume_comparator.rb
+++ b/lib/hako/schedulers/ecs_volume_comparator.rb
@@ -25,6 +25,7 @@ module Hako
           struct.member(:efs_volume_configuration, Schema::Nullable.new(efs_volume_configuration_schema))
           struct.member(:host, Schema::Nullable.new(host_schema))
           struct.member(:name, Schema::String.new)
+          struct.member(:configured_at_launch, Schema::Nullable.new(Schema::Boolean.new))
         end
       end
 

--- a/spec/hako/schedulers/ecs_spec.rb
+++ b/spec/hako/schedulers/ecs_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Hako::Schedulers::Ecs do
       platform_version: nil,
       network_configuration: nil,
       health_check_grace_period_seconds: nil,
+      volume_configurations: nil,
       propagate_tags: 'TASK_DEFINITION',
     }
   end
@@ -55,6 +56,7 @@ RSpec.describe Hako::Schedulers::Ecs do
       platform_version: nil,
       network_configuration: nil,
       health_check_grace_period_seconds: nil,
+      volume_configurations: nil,
     }
   end
   let(:register_task_definition_params) do
@@ -549,6 +551,7 @@ RSpec.describe Hako::Schedulers::Ecs do
           platform_version: nil,
           network_configuration: nil,
           propagate_tags: 'TASK_DEFINITION',
+          volume_configurations: nil,
         ).and_return(Aws::ECS::Types::RunTaskResponse.new(
           failures: [],
           tasks: [


### PR DESCRIPTION
I've implemented the attachment of an EBS volume to the ECS.

I'd like to attach ephemeral volumes larger than 200GB in Fargate, and with EBS it can specify volume sizes from 1 to 16,384GiB.

I've referred to the following documents:

- https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specify-ebs-config.html
- https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html
- https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service_definition_parameters.html

Please review it.