### PR TITLE
Load dependent containers on `hako oneshot`

### DIFF
--- a/lib/hako/definition_loader.rb
+++ b/lib/hako/definition_loader.rb
@@ -50,9 +50,18 @@ module Hako
               Container.new(@app, sidecars.fetch(name), dry_run: @dry_run)
             end
 
+          # Load linked containers
           containers[name].links.each do |link|
             m = link.match(/\A([^:]+):([^:]+)\z/)
             names << (m ? m[1] : link)
+          end
+
+          # Load dependent containers
+          depends_on = containers[name].depends_on
+          if depends_on
+            depends_on.each do |depend_on|
+              names << depend_on.fetch(:container_name)
+            end
           end
 
           containers[name].volumes_from.each do |volumes_from|

--- a/spec/fixtures/jsonnet/default_with_depends_on.jsonnet
+++ b/spec/fixtures/jsonnet/default_with_depends_on.jsonnet
@@ -1,0 +1,47 @@
+{
+  app: {
+    image: 'app-image',
+    links: ['redis'],
+    depends_on: [
+      { container_name: 'init2', condition: 'SUCCESS' },
+    ],
+    mount_points: [
+      { source_volume: 'data', container_path: '/data', read_only: true },
+    ],
+  },
+  sidecars: {
+    redis: {
+      image_tag: 'redis',
+      links: ['memcached'],
+    },
+    memcached: {
+      image_tag: 'memcached',
+    },
+    fluentd: {
+      image_tag: 'fluentd',
+      links: ['redis'],
+    },
+    init: {
+      essential: false,
+      image_tag: 'busybox',
+      command: ['mkdir', '-p', '/data/mydir'],
+      mount_points: [
+        { source_volume: 'data', container_path: '/data' },
+      ],
+    },
+    init2: {
+      essential: false,
+      image_tag: 'busybox',
+      command: ['touch', '/data/mydir/ok.txt'],
+      depends_on: [
+        { container_name: 'init', condition: 'SUCCESS' },
+      ],
+      mount_points: [
+        { source_volume: 'data', container_path: '/data' },
+      ],
+    },
+  },
+  volumes: {
+    data: {},
+  },
+}

--- a/spec/hako/definition_loader_spec.rb
+++ b/spec/hako/definition_loader_spec.rb
@@ -47,6 +47,23 @@ RSpec.describe Hako::DefinitionLoader do
       end
     end
 
+    context 'with depends_on' do
+      let(:fixture_name) { 'default_with_depends_on.jsonnet' }
+
+      it 'loads all containers' do
+        containers = definition_loader.load
+        expect(containers.keys).to match_array(%w[app redis memcached fluentd init init2])
+        expect(containers.values).to all(be_a(Hako::Container))
+      end
+
+      context 'with `with`' do
+        it 'loads specified definition and linked containers and dependent containers' do
+          containers = definition_loader.load(with: [])
+          expect(containers.keys).to match_array(%w[app redis memcached init init2])
+        end
+      end
+    end
+
     context 'with volumes_from' do
       let(:fixture_name) { 'default_with_volumes_from.jsonnet' }
 


### PR DESCRIPTION
Currently, `hako oneshot` loads the app container and sidecars linked from the app container. However, this behavior is inconvenient when the task contains an initializing sidecar. Suppose the app container uses a Docker volume and the volume must be initialized first. This requirement can be achieved as follows.

```jsonnet
{
  app: {
    depends_on: [
      { container_name: 'init', condition: 'SUCCESS' },
    ],
    mount_points: [
      { source_volume: 'data', container_path: '/data', read_only: true },
    ],
  },
  sidecars: {
    init: {
      essential: false,
      command: ['do-initialize', '/data'],
      mount_points: [
        { source_volume: 'data', container_path: '/data' },
      ],
    },
  },
```

In this case, `hako oneshot` should load the init sidecar by default for convenience.